### PR TITLE
回答時間のボーナス概念を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ bin/rails s
 rspec
 ```
 
+## Lint
+
+- auto-correct を利用する
+```bash
+rubocop -a
+```
+
 ## ライセンス
 
 MIT License

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -230,7 +230,7 @@ export default class extends Controller {
     const score = data.game.score || 0
     this.finalScoreTarget.textContent = score
 
-    // ゲーム時間とタイムボーナスが含まれている場合は表示
+    // ゲーム時間が含まれている場合は表示
     if (data.game.duration_seconds) {
       const duration = data.game.duration_seconds
       const durationText = `プレイ時間: ${this.formatDuration(duration)}`
@@ -240,7 +240,6 @@ export default class extends Controller {
       scoreDetails.className = "score-details"
       scoreDetails.innerHTML = `
         <div class="duration-info">${durationText}</div>
-        ${data.time_bonus ? `<div class="bonus-info">タイムボーナス: ×${data.time_bonus}</div>` : ''}
       `
 
       // すでに詳細が表示されている場合は置き換え、なければ追加
@@ -338,31 +337,31 @@ export default class extends Controller {
 
     // 単語と番号を表示
     const turnNumber = this.gameState.usedWords.length + 1
-    const turnNumberSpan = document.createElement("span");
-    turnNumberSpan.textContent = `${turnNumber}. ${word}`;
-    const playerSpan = document.createElement("span");
-    playerSpan.textContent = player === "player" ? "あなた" : "コンピューター";
-    li.appendChild(turnNumberSpan);
-    li.appendChild(playerSpan);
+    const turnNumberSpan = document.createElement("span")
+    turnNumberSpan.textContent = `${turnNumber}. ${word}`
+    const playerSpan = document.createElement("span")
+    playerSpan.textContent = player === "player" ? "あなた" : "コンピューター"
+    li.appendChild(turnNumberSpan)
+    li.appendChild(playerSpan)
     this.wordListTarget.appendChild(li)
 
     // 最新の単語が見えるようにスクロール
     this.wordListTarget.scrollTop = this.wordListTarget.scrollHeight
   }
-// エラーメッセージを表示
-showError(message) {
-  this.errorMessageTarget.textContent = message
-  this.errorMessageTarget.classList.add("error")
 
-  // エラーの場合は、現在の単語を更新せず、明確にエラー表示する
-  this.currentWordTarget.innerHTML = `<span class="error-highlight">${this.gameState.lastWord || "ゲーム開始"}</span>`;
+  // エラーメッセージを表示
+  showError(message) {
+    this.errorMessageTarget.textContent = message
+    this.errorMessageTarget.classList.add("error")
 
-  // 5秒後にエラーメッセージを消去（時間を延長）
-  setTimeout(() => {
-    this.errorMessageTarget.textContent = ""
-    this.errorMessageTarget.classList.remove("error")
-  }, 5000)
-}
+    // エラーの場合は、現在の単語を更新せず、明確にエラー表示する
+    this.currentWordTarget.innerHTML = `<span class="error-highlight">${this.gameState.lastWord || "ゲーム開始"}</span>`
+
+    // 5秒後にエラーメッセージを消去（時間を延長）
+    setTimeout(() => {
+      this.errorMessageTarget.textContent = ""
+      this.errorMessageTarget.classList.remove("error")
+    }, 5000)
   }
 
   // 情報メッセージを表示
@@ -375,7 +374,7 @@ showError(message) {
       this.errorMessageTarget.textContent = ""
       this.errorMessageTarget.classList.remove("info")
     }, 3000)
-  };
+  }
 
   // カウントダウンを開始
   startCountdown() {
@@ -401,10 +400,10 @@ showError(message) {
         this.startTimer()
       }
     }, 1000)
-  };
+  }
 
   // CSRFトークンを取得
   getCSRFToken() {
     return document.querySelector('meta[name="csrf-token"]').getAttribute("content")
-  };
+  }
 }

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -15,11 +15,11 @@ class Word < ApplicationRecord
 
   # スコープ
   scope :by_type, ->(type) { where(word_type: type) }
-  scope :methods, -> { where(word_type: 'method') }
-  scope :keywords, -> { where(word_type: 'keyword') }
-  scope :classes, -> { where(word_type: 'class') }
-  scope :modules, -> { where(word_type: 'module') }
-  scope :gems, -> { where(word_type: 'gem') }
+  scope :methods, -> { where(word_type: "method") }
+  scope :keywords, -> { where(word_type: "keyword") }
+  scope :classes, -> { where(word_type: "class") }
+  scope :modules, -> { where(word_type: "module") }
+  scope :gems, -> { where(word_type: "gem") }
 
   # スコープ
   scope :by_first_letter, ->(letter) { where("LOWER(word) LIKE ?", "#{letter.downcase}%") }

--- a/app/services/games/score_calculator.rb
+++ b/app/services/games/score_calculator.rb
@@ -2,48 +2,19 @@ module Games
   class ScoreCalculator
     # スコア計算のパラメータ
     BASE_SCORE_PER_TURN = 100
-    MAX_TIME_BONUS = 1.5
-    OPTIMAL_SECONDS_PER_TURN = 10.0
-    MIN_SECONDS_PER_TURN = 1.0
 
     # スコアを計算する
     # @param turn_count [Integer] ターン数
     # @param duration_seconds [Integer] ゲーム時間（秒）
     # @return [Hash] スコア情報
     def calculate(turn_count, duration_seconds)
-      # 基本スコア = ターン数 * BASE_SCORE_PER_TURN
-      turn_score = turn_count * BASE_SCORE_PER_TURN
-
-      # 時間に応じたボーナス係数を計算
-      time_bonus = calculate_time_bonus(turn_count, duration_seconds)
-
-      # 最終スコア = ターンスコア * 時間ボーナス
-      final_score = (turn_score * time_bonus).to_i
+      # スコア = ターン数 * BASE_SCORE_PER_TURN
+      score = turn_count * BASE_SCORE_PER_TURN
 
       {
-        score: final_score,
-        time_bonus: time_bonus.round(2),
-        turn_score: turn_score
+        score: score,
+        turn_score: score
       }
-    end
-
-    private
-
-    # 時間ボーナスを計算する
-    # @param turn_count [Integer] ターン数
-    # @param duration_seconds [Integer] ゲーム時間（秒）
-    # @return [Float] 時間ボーナス係数
-    def calculate_time_bonus(turn_count, duration_seconds)
-      # ターン数や時間が0以下の場合はボーナスなし
-      return 1.0 if turn_count <= 0 || duration_seconds <= 0
-
-      # 平均ターン時間（秒）を計算
-      avg_seconds_per_turn = duration_seconds.to_f / turn_count
-
-      # 最適時間とのレシオを求め、ボーナスを計算
-      # 平均5秒/ターンなら1.5倍、平均20秒/ターンなら0.75倍など
-      ratio = OPTIMAL_SECONDS_PER_TURN / [ avg_seconds_per_turn, MIN_SECONDS_PER_TURN ].max
-      [ ratio, MAX_TIME_BONUS ].min
     end
   end
 end

--- a/app/services/games/session_manager.rb
+++ b/app/services/games/session_manager.rb
@@ -146,8 +146,7 @@ module Games
         game_over: true,
         reason: reason,
         score: @game.score,
-        duration: duration,
-        time_bonus: score_info[:time_bonus]
+        duration: duration
       }
     end
 

--- a/lib/tasks/import_words.rake
+++ b/lib/tasks/import_words.rake
@@ -1,8 +1,8 @@
-require 'nokogiri'
-require 'open-uri'
-require 'fileutils'
-require 'tmpdir'
-require 'json'
+require "nokogiri"
+require "open-uri"
+require "fileutils"
+require "tmpdir"
+require "json"
 
 namespace :words do
   RUBY_KEYWORDS = %w[
@@ -11,18 +11,18 @@ namespace :words do
     super then true undef unless until when while yield
   ].freeze
 
-  desc 'Import Ruby keywords'
+  desc "Import Ruby keywords"
   task import_keywords: :environment do
-    puts 'Importing Ruby keywords...'
+    puts "Importing Ruby keywords..."
 
     RUBY_KEYWORDS.each do |keyword|
       begin
         Word.find_or_create_by!(word: keyword) do |w|
           w.normalized_word = keyword.downcase
           w.description = "Ruby keyword: #{get_keyword_description(keyword)}"
-          w.word_type = 'keyword'
+          w.word_type = "keyword"
         end
-        print '.'
+        print "."
       rescue ActiveRecord::RecordInvalid => e
         puts "\nSkipped '#{keyword}': #{e.message}"
       end
@@ -31,16 +31,16 @@ namespace :words do
     puts "\nKeywords import completed!"
   end
 
-  desc 'Import words from rurema/doctree repository'
+  desc "Import words from rurema/doctree repository"
   task import_from_doctree: :environment do
     # クローンするリポジトリのURL
-    repo_url = 'https://github.com/rurema/doctree.git'
+    repo_url = "https://github.com/rurema/doctree.git"
 
     Dir.mktmpdir do |tmp_dir|
-      puts 'Cloning rurema/doctree repository...'
+      puts "Cloning rurema/doctree repository..."
       system("git clone --depth 1 #{repo_url} #{tmp_dir}")
 
-      puts 'Scanning rdoc files...'
+      puts "Scanning rdoc files..."
       words = extract_words_from_rdoc("#{tmp_dir}/refm/api/src")
 
       puts "Found #{words.length} potential terms"
@@ -50,13 +50,13 @@ namespace :words do
     end
   end
 
-  desc 'Update descriptions for Ruby methods from documentation'
+  desc "Update descriptions for Ruby methods from documentation"
   task update_descriptions: :environment do
-    puts 'Updating descriptions from Ruby documentation...'
+    puts "Updating descriptions from Ruby documentation..."
 
     Dir.mktmpdir do |tmp_dir|
       # ruremaリポジトリをクローン
-      repo_url = 'https://github.com/rurema/doctree.git'
+      repo_url = "https://github.com/rurema/doctree.git"
       system("git clone --depth 1 #{repo_url} #{tmp_dir}")
 
       # メソッドの説明を更新
@@ -73,84 +73,84 @@ namespace :words do
 
   def get_keyword_description(keyword)
     case keyword
-    when 'BEGIN'
-      'Runs before the main program execution begins'
-    when 'END'
-      'Runs after the main program execution ends'
-    when 'alias'
-      'Creates an alias for an existing method, operator, or global variable'
-    when 'and'
-      'Logical operator that returns true if both operands are true'
-    when 'begin'
-      'Begins a code block or method definition that may raise an exception'
-    when 'break'
-      'Terminates a loop or switch statement and transfers control'
-    when 'case'
-      'Starts a case expression for pattern matching'
-    when 'class'
-      'Defines a new class'
-    when 'def'
-      'Defines a new method'
-    when 'defined?'
-      'Tests whether a given expression is defined'
-    when 'do'
-      'Starts a block'
-    when 'else'
-      'Alternative condition in if/unless/case statements'
-    when 'elsif'
-      'Alternative condition if previous conditions are false'
-    when 'end'
-      'Ends a code block, class, module, or method definition'
-    when 'ensure'
-      'Ensures that a block of code is always executed'
-    when 'false'
-      'Boolean false value'
-    when 'for'
-      'Loop construct for iterating over a collection'
-    when 'if'
-      'Conditional statement that executes code if condition is true'
-    when 'in'
-      'Used in pattern matching to specify patterns'
-    when 'module'
-      'Defines a module'
-    when 'next'
-      'Jumps to the next iteration of a loop'
-    when 'nil'
-      'Represents absence of a value'
-    when 'not'
-      'Logical operator that returns the opposite of a boolean value'
-    when 'or'
-      'Logical operator that returns true if either operand is true'
-    when 'redo'
-      'Restarts the current iteration of a loop'
-    when 'rescue'
-      'Handles exceptions in begin/end blocks'
-    when 'retry'
-      'Retries a begin/end block after an exception'
-    when 'return'
-      'Returns a value from a method'
-    when 'self'
-      'References the current object'
-    when 'super'
-      'Calls the same method in the parent class'
-    when 'then'
-      'Optional separator in if/when statements'
-    when 'true'
-      'Boolean true value'
-    when 'undef'
-      'Removes a method definition'
-    when 'unless'
-      'Conditional statement that executes code if condition is false'
-    when 'until'
-      'Loop that executes while condition is false'
-    when 'when'
-      'Condition in case statements'
-    when 'while'
-      'Loop that executes while condition is true'
-    when 'yield'
-      'Calls the block passed to a method'
+    when "BEGIN"
+      "Runs before the main program execution begins"
+    when "END"
+      "Runs after the main program execution ends"
+    when "alias"
+      "Creates an alias for an existing method, operator, or global variable"
+    when "and"
+      "Logical operator that returns true if both operands are true"
+    when "begin"
+      "Begins a code block or method definition that may raise an exception"
+    when "break"
+      "Terminates a loop or switch statement and transfers control"
+    when "case"
+      "Starts a case expression for pattern matching"
+    when "class"
+      "Defines a new class"
+    when "def"
+      "Defines a new method"
+    when "defined?"
+      "Tests whether a given expression is defined"
+    when "do"
+      "Starts a block"
+    when "else"
+      "Alternative condition in if/unless/case statements"
+    when "elsif"
+      "Alternative condition if previous conditions are false"
+    when "end"
+      "Ends a code block, class, module, or method definition"
+    when "ensure"
+      "Ensures that a block of code is always executed"
+    when "false"
+      "Boolean false value"
+    when "for"
+      "Loop construct for iterating over a collection"
+    when "if"
+      "Conditional statement that executes code if condition is true"
+    when "in"
+      "Used in pattern matching to specify patterns"
+    when "module"
+      "Defines a module"
+    when "next"
+      "Jumps to the next iteration of a loop"
+    when "nil"
+      "Represents absence of a value"
+    when "not"
+      "Logical operator that returns the opposite of a boolean value"
+    when "or"
+      "Logical operator that returns true if either operand is true"
+    when "redo"
+      "Restarts the current iteration of a loop"
+    when "rescue"
+      "Handles exceptions in begin/end blocks"
+    when "retry"
+      "Retries a begin/end block after an exception"
+    when "return"
+      "Returns a value from a method"
+    when "self"
+      "References the current object"
+    when "super"
+      "Calls the same method in the parent class"
+    when "then"
+      "Optional separator in if/when statements"
+    when "true"
+      "Boolean true value"
+    when "undef"
+      "Removes a method definition"
+    when "unless"
+      "Conditional statement that executes code if condition is false"
+    when "until"
+      "Loop that executes while condition is false"
+    when "when"
+      "Condition in case statements"
+    when "while"
+      "Loop that executes while condition is true"
+    when "yield"
+      "Calls the block passed to a method"
     else
-      'Ruby language keyword'
+      "Ruby language keyword"
     end
   end
 
@@ -184,7 +184,7 @@ namespace :words do
           w.normalized_word = normalized_word
           w.description = "Ruby standard library term"
         end
-        print '.'
+        print "."
       rescue ActiveRecord::RecordInvalid => e
         puts "\nSkipped '#{word}': #{e.message}"
       end
@@ -192,7 +192,7 @@ namespace :words do
   end
 
   def update_method_descriptions(base_path)
-    puts 'Updating method descriptions...'
+    puts "Updating method descriptions..."
     Word.find_each do |word|
       # メソッド名に対応するドキュメントファイルを検索
       method_files = Dir.glob("#{base_path}/**/*.rd").select do |file|
@@ -207,7 +207,7 @@ namespace :words do
       if (match = content.match(/--- .*#{word.word}.*\n+(.*?)(\n\n|\z)/m))
         description = match[1].strip
         word.update(description: description) unless description.empty?
-        print '.'
+        print "."
       end
     end
   end
@@ -215,18 +215,18 @@ namespace :words do
   def update_gem_descriptions
     puts "\nUpdating gem descriptions..."
     # RubyGemsのAPIから人気のGemを取得
-    gems_url = 'https://rubygems.org/api/v1/search.json?query=&page=1&order=downloads'
+    gems_url = "https://rubygems.org/api/v1/search.json?query=&page=1&order=downloads"
     response = URI.open(gems_url).read
     gems = JSON.parse(response)
 
     gems.each do |gem_info|
-      gem_name = gem_info['name']
+      gem_name = gem_info["name"]
       # gemの名前に対応する単語があれば説明を更新
       if (word = Word.find_by(normalized_word: gem_name.downcase))
         word.update(
           description: "Ruby gem: #{gem_info['info']}"
         )
-        print '.'
+        print "."
       end
     end
   end

--- a/spec/services/games/session_manager_spec.rb
+++ b/spec/services/games/session_manager_spec.rb
@@ -172,7 +172,6 @@ RSpec.describe Games::SessionManager do
       # ScoreCalculatorをモックして、テスト用のスコアを返すようにする
       allow_any_instance_of(Games::ScoreCalculator).to receive(:calculate).and_return({
         score: 200,
-        time_bonus: 1.0,
         turn_score: 200
       })
 


### PR DESCRIPTION
## 変更内容

「回答時間のボーナス」という概念を削除しました。これは元々の要件にはなかった機能です。

具体的には以下の変更を行いました：
1. スコア計算からタイムボーナスの乗算処理を削除
2. ゲームセッションマネージャーからタイムボーナス情報の返却処理を削除
3. フロントエンドのタイムボーナス表示部分を削除
4. テストコードからタイムボーナス関連部分を修正