### PR TITLE
初期データ投入をrake db:seedで実行できるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,8 @@ bin/rails db:migrate
 
 4. 初期データの準備
 ```bash
-# Rubyドキュメントから単語をインポート
-bundle exec rake words:import_from_doctree
-
-# 単語の説明を更新
-bundle exec rake words:update_descriptions
+# 初期データの投入（単語のインポートと説明の更新を行います）
+bin/rails db:seed
 ```
 
 5. アプリケーションの起動

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,16 @@
 # This file should ensure the existence of records required to run the application in every environment (production,
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+
+puts "=== シードデータの準備を開始します ==="
+
+# Rubyキーワードのインポート
+Rake::Task["words:import_keywords"].invoke
+
+# Rubyドキュメントから単語をインポート
+Rake::Task["words:import_from_doctree"].invoke
+
+# 単語の説明を更新
+Rake::Task["words:update_descriptions"].invoke
+
+puts "=== シードデータの準備が完了しました ==="


### PR DESCRIPTION
## 変更内容

- db/seeds.rb を修正して、 で初期データを投入できるようにしました
- README.md の初期データ投入手順を更新しました

## 変更の詳細

このPRでは、以下の変更を行いました：

1. db/seeds.rbに以下のRakeタスクを呼び出すコードを追加
   - words:import_keywords
   - words:import_from_doctree
   - words:update_descriptions

2. README.mdのセットアップ手順を更新し、複数のRakeタスクの代わりに  コマンド一つで初期データを投入できるようにしました

これにより、初期セットアップの手順がシンプルになり、ユーザー体験が向上します。