### PR TITLE
無効な単語入力時にタイマーがリセットされる問題を修正

### DIFF
--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -201,8 +201,7 @@ export default class extends Controller {
         this.wordInputTarget.focus();
 
         // 単語がDBにない場合は、単語履歴やゲーム状態を更新しない
-        // タイマーのみ再開
-        this.resetTimer();
+        // タイマーを継続（リセットせず再開）
         this.startTimer();
       });
   }
@@ -289,8 +288,7 @@ export default class extends Controller {
     // 既存のタイマーをクリア
     this.stopTimer();
 
-    // タイマーの初期化
-    this.gameState.timeLeft = this.timerDurationValue;
+    // タイマーの表示を更新
     this.timerTarget.textContent = this.gameState.timeLeft;
     this.timerTarget.classList.remove("time-critical");
 


### PR DESCRIPTION
無効な単語入力時にタイマーがリセットされる問題を修正しました。これにより、ルール違反の単語を連続入力して時間切れを回避できる問題が解決されました。