### PR TITLE
GitHub Actions OIDCの認証方法を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,39 +18,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Debug OIDC claims
-        id: get_id_token
-        uses: actions/checkout@v4
-
-      - name: Get ID Token
-        id: idtoken
-        run: |
-          # GitHub Actionsの組み込み関数を使用してIDトークンを取得
-          TOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')
-          if [ -z "$TOKEN" ]; then
-            echo "Failed to get ID token"
-            exit 1
-          fi
-
-          # トークンのペイロード部分をデコード
-          PAYLOAD=$(echo $TOKEN | cut -d. -f2 | base64 -d 2>/dev/null || echo $TOKEN | cut -d. -f2 | base64 -di 2>/dev/null)
-          echo "OIDC Token payload:"
-          echo $PAYLOAD | jq .
-
-          # subクレームを抽出
-          SUB_CLAIM=$(echo $PAYLOAD | jq -r .sub)
-          echo "Sub claim: $SUB_CLAIM"
-          echo "sub_claim=$SUB_CLAIM" >> $GITHUB_OUTPUT
-        env:
-          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
-          ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-role
           aws-region: ${{ secrets.AWS_REGION }}
           audience: sts.amazonaws.com
+
+      - name: Debug OIDC Token
+        run: |
+          # AWS認証情報が正常に設定されたことを確認
+          echo "AWS credentials configured: $(aws sts get-caller-identity --query 'Account' --output text)"
+
+          # IAMロールの情報を表示
+          echo "Assumed role: $(aws sts get-caller-identity --query 'Arn' --output text)"
 
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
## 変更の概要

- GitHub Actions OIDCの認証方法を修正
- 非推奨または存在しないアクションを削除
- アクションを直接使用するように変更
- デバッグ情報を追加して認証状態を確認できるように改善

## 詳細

GitHub Actionsのデプロイワークフローで「Error: Missing download info for actions/id-token@v2」というエラーが発生していました。このエラーはアクションが存在しないか非推奨になったことが原因です。

最新のOIDC認証方法では、アクションを使用せず、直接アクションを使用することが推奨されています。このアクションは内部でOIDCトークンを取得し、AWSの認証を行います。

また、デバッグ用のステップを追加して、AWS認証情報が正常に設定されたことを確認できるようにしました。