### PR TITLE
Fix ECS task definition deployment error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,14 +116,14 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1.1.0
+        uses: aws-actions/amazon-ecs-render-task-definition@v1.7.1
         with:
           task-definition: task-definition.json
           container-name: shiritoruby
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1.4.0
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2.3.1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: shiritoruby-service

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,12 @@ jobs:
             --task-definition shiritoruby \
             --query taskDefinition > task-definition.json
 
+      - name: Clean task definition
+        run: |
+          # 不要なプロパティを削除
+          jq 'del(.taskDefinitionArn, .status, .revision, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' task-definition.json > cleaned-task-definition.json
+          mv cleaned-task-definition.json task-definition.json
+
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1.1.0

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -201,7 +201,9 @@ CDパイプラインを実行するためには、以下のGitHub Secretsを設�
 
 ### ECSタスク定義のデプロイエラー
 
-ECSタスク定義をデプロイする際に以下のようなエラーが発生する場合：
+ECSタスク定義をデプロイする際に以下のようなエラーが発生する場合があります：
+
+1. 不要なプロパティによるエラー：
 
 ```
 Error: Failed to register task definition in ECS: There were 2 validation errors:
@@ -232,6 +234,36 @@ Error: Failed to register task definition in ECS: There were 2 validation errors
 ```
 
 2. この修正を`.github/workflows/deploy.yml`ファイルの「Download task definition」ステップの後に追加します。
+
+2. デプロイコントローラーのエラー：
+
+```
+Error: Unsupported deployment controller: ECS
+```
+
+これは、GitHub Actionsで使用しているアクションのバージョンが古い場合に発生することがあります。以下のアクションを最新バージョンに更新することで解決できます：
+
+1. `aws-actions/amazon-ecs-render-task-definition`
+2. `aws-actions/amazon-ecs-deploy-task-definition`
+
+例：
+```yaml
+- name: Fill in the new image ID in the Amazon ECS task definition
+  id: task-def
+  uses: aws-actions/amazon-ecs-render-task-definition@v1.7.1
+  with:
+    task-definition: task-definition.json
+    container-name: shiritoruby
+    image: ${{ steps.build-image.outputs.image }}
+
+- name: Deploy Amazon ECS task definition
+  uses: aws-actions/amazon-ecs-deploy-task-definition@v2.3.1
+  with:
+    task-definition: ${{ steps.task-def.outputs.task-definition }}
+    service: shiritoruby-service
+    cluster: shiritoruby-cluster
+    wait-for-service-stability: true
+```
 
 ### アプリケーションが正常に動作しない場合
 

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -199,6 +199,40 @@ CDパイプラインを実行するためには、以下のGitHub Secretsを設�
    - OIDC認証の場合：IAMロールに必要な権限が付与されていることを確認します。
 4. ECRリポジトリ、ECSクラスター、サービス名が正しいことを確認します。
 
+### ECSタスク定義のデプロイエラー
+
+ECSタスク定義をデプロイする際に以下のようなエラーが発生する場合：
+
+```
+Error: Failed to register task definition in ECS: There were 2 validation errors:
+* UnexpectedParameter: Unexpected key 'registeredAt' found in params
+* UnexpectedParameter: Unexpected key 'registeredBy' found in params
+```
+
+これは、`aws ecs describe-task-definition`コマンドで取得したタスク定義に、新しいタスク定義を登録する際には不要（または許可されていない）プロパティが含まれているためです。以下のプロパティが問題になることがあります：
+
+- compatibilities
+- taskDefinitionArn
+- requiresAttributes
+- revision
+- status
+- registeredAt
+- registeredBy
+
+解決策：
+
+1. タスク定義をダウンロードした後、不要なプロパティを削除するステップをワークフローに追加します：
+
+```yaml
+- name: Clean task definition
+  run: |
+    # 不要なプロパティを削除
+    jq 'del(.taskDefinitionArn, .status, .revision, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' task-definition.json > cleaned-task-definition.json
+    mv cleaned-task-definition.json task-definition.json
+```
+
+2. この修正を`.github/workflows/deploy.yml`ファイルの「Download task definition」ステップの後に追加します。
+
 ### アプリケーションが正常に動作しない場合
 
 1. ECSサービスのログを確認します：


### PR DESCRIPTION
## 変更の概要

- GitHub ActionsのデプロイワークフローでECSタスク定義のデプロイ時に発生するエラーを修正
- タスク定義から不要なプロパティ（registeredAt, registeredBy等）を削除するステップを追加
- CI/CDドキュメントのトラブルシューティングセクションに関連情報を追加

## 詳細

ECSタスク定義をデプロイする際に、コマンドで取得したタスク定義に、新しいタスク定義を登録する際には不要（または許可されていない）プロパティが含まれていることが原因でエラーが発生していました。この修正では、タスク定義から不要なプロパティを削除するステップをワークフローに追加しています。