### PR TITLE
ゲーム開始時のエラーハンドリングを改善

### DIFF
--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -30,13 +30,25 @@ class Api::GamesController < ApplicationController
   # 新しいゲームを作成
   def create
     player_name = params[:player_name] || "ゲスト"
-    @session_manager = Games::SessionManager.new(player_name)
-    session[:game_id] = @session_manager.game.id
 
-    render json: {
-      message: "新しいゲームを開始しました",
-      game: @session_manager.game_state
-    }, status: :created
+    begin
+      @session_manager = Games::SessionManager.new(player_name)
+      session[:game_id] = @session_manager.game.id
+
+      render json: {
+        message: "新しいゲームを開始しました",
+        game: @session_manager.game_state
+      }, status: :created
+    rescue => e
+      # エラーをログに記録
+      Rails.logger.error "ゲーム作成エラー: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+
+      # JSONレスポンスを返す
+      render json: {
+        error: "ゲームの作成に失敗しました: #{e.message}"
+      }, status: :unprocessable_entity
+    end
   end
 
   # POST /api/games/submit_word

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -75,7 +75,14 @@ export default class extends Controller {
       },
       body: JSON.stringify({ player_name: playerName }),
     })
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) {
+          return response.json().then((data) => {
+            throw new Error(data.error || "ゲームの開始に失敗しました");
+          });
+        }
+        return response.json();
+      })
       .then((data) => {
         // ゲーム状態をリセット
         this.resetGameState();
@@ -97,7 +104,8 @@ export default class extends Controller {
       .catch((error) => {
         console.error("ゲーム開始エラー:", error);
         this.showError(
-          "ゲームを開始できませんでした。もう一度お試しください。",
+          error.message ||
+            "ゲームを開始できませんでした。もう一度お試しください。"
         );
       });
   }
@@ -252,7 +260,11 @@ export default class extends Controller {
       scoreDetails.className = "score-details";
       scoreDetails.innerHTML = `
         <div class="duration-info">${durationText}</div>
-        ${data.time_bonus ? `<div class="bonus-info">タイムボーナス: ×${data.time_bonus}</div>` : ""}
+        ${
+          data.time_bonus
+            ? `<div class="bonus-info">タイムボーナス: ×${data.time_bonus}</div>`
+            : ""
+        }
       `;
 
       // すでに詳細が表示されている場合は置き換え、なければ追加
@@ -367,7 +379,9 @@ export default class extends Controller {
     this.errorMessageTarget.classList.add("error");
 
     // エラーの場合は、現在の単語を更新せず、明確にエラー表示する
-    this.currentWordTarget.innerHTML = `<span class="error-highlight">${this.gameState.lastWord || "ゲーム開始"}</span>`;
+    this.currentWordTarget.innerHTML = `<span class="error-highlight">${
+      this.gameState.lastWord || "ゲーム開始"
+    }</span>`;
 
     // 5秒後にエラーメッセージを消去（時間を延長）
     setTimeout(() => {

--- a/app/services/games/session_manager.rb
+++ b/app/services/games/session_manager.rb
@@ -39,13 +39,26 @@ module Games
     # ゲームを作成し、初期化する
     # @return [Game] 作成されたゲームのインスタンス
     def create_game
-      @game = Game.create!(
-        player_name: @player_name,
-        score: 0
-      )
-      @current_state = GAME_STATE[:player_turn]
-      @player_turn = true
-      @game
+      begin
+        @game = Game.create!(
+          player_name: @player_name,
+          score: 0
+        )
+        @current_state = GAME_STATE[:player_turn]
+        @player_turn = true
+        @game
+      rescue ActiveRecord::RecordInvalid => e
+        # バリデーションエラーの詳細なメッセージを含める
+        error_message = "ゲームの作成に失敗しました: #{e.message}"
+        Rails.logger.error error_message
+        raise GameSessionError, error_message
+      rescue => e
+        # その他のエラー
+        error_message = "予期せぬエラーが発生しました: #{e.message}"
+        Rails.logger.error error_message
+        Rails.logger.error e.backtrace.join("\n")
+        raise GameSessionError, error_message
+      end
     end
 
     # プレイヤーのターンを処理


### PR DESCRIPTION
## 変更の概要

- ゲーム開始ボタン押下時に発生する422エラーの問題を修正
- サーバー側でのエラーハンドリングを改善し、JSONレスポンスを返すように変更
- フロントエンド側でのエラーハンドリングを改善し、詳細なエラーメッセージを表示するように変更

## 詳細

トップ画面で「ゲーム開始」ボタンを押下すると422エラーが発生し、HTMLが返されていた問題を修正しました。サーバー側でエラーが発生した場合でもJSONレスポンスを返すようにし、フロントエンド側でそのエラーメッセージを適切に表示するようにしました。

具体的な変更点：
1. アクションに例外処理を追加
2. メソッドに例外処理を追加
3. フロントエンド側の `game_controller.js` のエラーハンドリングを改善
