### PR TITLE
セッションIDの処理を修正し、ゲーム中の単語送信エラーを解消

### DIFF
--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -101,7 +101,8 @@ export default class extends Controller {
       .then((data) => {
         // セッションIDを保存（レスポンスヘッダーから取得）
         if (data.session_id) {
-          this.sessionId = data.session_id;
+          // セッションIDを確実に文字列として扱う
+          this.sessionId = String(data.session_id);
           console.log("セッションID保存:", this.sessionId);
         }
         return data;
@@ -156,7 +157,9 @@ export default class extends Controller {
 
     // セッションIDをURLパラメータとして追加
     const url = this.sessionId
-      ? `${this.apiBaseUrl}/submit_word?session_id=${this.sessionId}`
+      ? `${this.apiBaseUrl}/submit_word?session_id=${encodeURIComponent(
+          this.sessionId
+        )}`
       : `${this.apiBaseUrl}/submit_word`;
 
     fetch(url, {
@@ -262,7 +265,9 @@ export default class extends Controller {
   handleTimeout() {
     // セッションIDをURLパラメータとして追加
     const url = this.sessionId
-      ? `${this.apiBaseUrl}/timeout?session_id=${this.sessionId}`
+      ? `${this.apiBaseUrl}/timeout?session_id=${encodeURIComponent(
+          this.sessionId
+        )}`
       : `${this.apiBaseUrl}/timeout`;
 
     fetch(url, {


### PR DESCRIPTION
## 変更の概要

- セッションIDをオブジェクトから文字列に変換するよう修正
- URLパラメータにセッションIDを追加する際にencodeURIComponentを使用
- タイムアウト処理でも同様の修正を適用

## 詳細

ゲーム開始後に単語を送信すると「ゲームセッションが見つかりません」というエラーが発生していた問題を修正しました。

原因はセッションIDがJavaScriptオブジェクトとして扱われ、URLパラメータに`[object Object]`という文字列として含まれていたことでした。これにより、バックエンドでセッションを復元できず、エラーが発生していました。

修正内容：
1. セッションIDを保存する際に`String()`を使用して確実に文字列に変換
2. URLパラメータとして追加する際に`encodeURIComponent()`でエンコード
3. タイムアウト処理でも同様の修正を適用"