### PR TITLE
セッションID処理を強化し、オブジェクト型の場合の対応を追加

### DIFF
--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -36,10 +36,11 @@ class Api::GamesController < ApplicationController
       session[:game_id] = @session_manager.game.id
 
       # セッションIDをレスポンスに含める
-      session_id = request.session.id.to_s
+      session_id = request.session.id
 
       # セッションIDの型をログに出力
-      Rails.logger.info "セッションID: #{session_id} (#{session_id.class})"
+      Rails.logger.info "セッションID: #{session_id} (Original Type: #{session_id.class})"
+      session_id = session_id.to_s
 
       render json: {
         message: "新しいゲームを開始しました",

--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -36,7 +36,11 @@ class Api::GamesController < ApplicationController
       session[:game_id] = @session_manager.game.id
 
       # セッションIDをレスポンスに含める
-      session_id = request.session.id
+      session_id = request.session.id.to_s
+
+      # セッションIDの型をログに出力
+      Rails.logger.info "セッションID: #{session_id} (#{session_id.class})"
+
       render json: {
         message: "新しいゲームを開始しました",
         game: @session_manager.game_state,

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -103,7 +103,30 @@ export default class extends Controller {
         if (data.session_id) {
           // セッションIDを確実に文字列として扱う
           this.sessionId = String(data.session_id);
-          console.log("セッションID保存:", this.sessionId);
+
+          // オブジェクトかどうかをチェック
+          if (typeof data.session_id === "object") {
+            console.warn(
+              "セッションIDがオブジェクトとして受信されました:",
+              data.session_id
+            );
+            // オブジェクトの場合は、JSONに変換して文字列化
+            if (data.session_id !== null) {
+              try {
+                this.sessionId = JSON.stringify(data.session_id);
+              } catch (e) {
+                console.error("セッションIDのJSON変換に失敗:", e);
+              }
+            }
+          }
+
+          console.log(
+            "セッションID保存:",
+            this.sessionId,
+            typeof this.sessionId
+          );
+        } else {
+          console.warn("セッションIDがレスポンスに含まれていません");
         }
         return data;
       })


### PR DESCRIPTION
## 変更の概要

- バックエンド側でセッションIDを明示的に文字列に変換
- セッションIDの型をログに出力して確認できるように改善
- フロントエンド側でセッションIDがオブジェクトとして受信された場合の処理を追加
- オブジェクトの場合はJSONに変換して文字列化する処理を実装
- より詳細なログ出力を追加

## 詳細

前回の修正でセッションIDを文字列として扱うようにしましたが、デプロイ後も同様のエラーが発生していました。今回の修正では、セッションIDの処理をさらに強化し、オブジェクト型の場合の対応を追加しました。

バックエンド側では、セッションIDを明示的に文字列に変換し、型情報をログに出力するようにしました。フロントエンド側では、セッションIDがオブジェクトとして受信された場合に、JSONに変換して文字列化する処理を追加しました。

これらの修正により、セッションIDが確実に文字列として扱われるようになり、エラーが解消されることが期待されます。