### PR TITLE
セッションID処理を大幅に改善し、ヘッダーベースの方式に変更

### DIFF
--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -178,18 +178,16 @@ export default class extends Controller {
       return;
     }
 
-    // セッションIDをURLパラメータとして追加
-    const url = this.sessionId
-      ? `${this.apiBaseUrl}/submit_word?session_id=${encodeURIComponent(
-          this.sessionId
-        )}`
-      : `${this.apiBaseUrl}/submit_word`;
+    // APIエンドポイントを設定
+    const url = `${this.apiBaseUrl}/submit_word`;
 
     fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "X-CSRF-Token": this.getCSRFToken(),
+        // セッションIDをヘッダーに含める
+        ...(this.sessionId ? { "X-Session-ID": this.sessionId } : {}),
       },
       body: JSON.stringify({ word }),
     })
@@ -286,18 +284,16 @@ export default class extends Controller {
 
   // タイムアウト時の処理
   handleTimeout() {
-    // セッションIDをURLパラメータとして追加
-    const url = this.sessionId
-      ? `${this.apiBaseUrl}/timeout?session_id=${encodeURIComponent(
-          this.sessionId
-        )}`
-      : `${this.apiBaseUrl}/timeout`;
+    // APIエンドポイントを設定
+    const url = `${this.apiBaseUrl}/timeout`;
 
     fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "X-CSRF-Token": this.getCSRFToken(),
+        // セッションIDをヘッダーに含める
+        ...(this.sessionId ? { "X-Session-ID": this.sessionId } : {}),
       },
     })
       .then((response) => {


### PR DESCRIPTION
## 変更の概要

- セッションIDをURLパラメータではなく、ヘッダー（X-Session-ID）に含めるように変更
- バックエンド側でヘッダーまたはURLパラメータからセッションIDを取得するように対応
- セッションIDの検索処理を改善（完全一致で見つからない場合は部分一致で検索）
- より詳細なログ出力を追加して、問題の特定を容易に
- セッションデータの解析処理を改善して、様々な型に対応

## 詳細

前回の修正でセッションIDを文字列として扱うようにしましたが、デプロイ後も同様のエラーが発生していました。今回の修正では、セッションIDの送信方法を根本的に見直し、URLパラメータではなくHTTPヘッダーを使用する方式に変更しました。

これにより、URLの長さ制限やエンコーディングの問題を回避し、より安定したセッション管理が可能になります。また、セッションIDの検索処理も改善し、完全一致で見つからない場合は部分一致で検索するなど、柔軟な対応を行うようにしました。

これらの修正により、「ゲームセッションが見つかりません」というエラーが解消されることが期待されます。