### PR TITLE
既存のインフラストラクチャをサポートするためのTerraform設定の修正

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,45 +1,45 @@
 output "ecr_repository_url" {
   description = "The URL of the ECR repository"
-  value       = aws_ecr_repository.shiritoruby.repository_url
+  value       = var.use_existing_infrastructure ? var.existing_ecr_repository_url : aws_ecr_repository.shiritoruby[0].repository_url
 }
 
 output "alb_dns_name" {
   description = "The DNS name of the load balancer"
-  value       = aws_lb.main.dns_name
+  value       = var.use_existing_infrastructure ? "" : aws_lb.main[0].dns_name
 }
 
 output "database_endpoint" {
   description = "The endpoint of the database"
-  value       = aws_db_instance.main.endpoint
+  value       = var.use_existing_infrastructure ? (try(data.aws_db_instance.main[0].endpoint, "")) : aws_db_instance.main[0].endpoint
 }
 
 output "ecs_cluster_name" {
   description = "The name of the ECS cluster"
-  value       = aws_ecs_cluster.main.name
+  value       = var.use_existing_infrastructure ? var.existing_ecs_cluster_name : aws_ecs_cluster.main[0].name
 }
 
 output "ecs_service_name" {
   description = "The name of the ECS service"
-  value       = aws_ecs_service.app.name
+  value       = "${var.app_name}-service"
 }
 
 output "ecr_push_commands" {
   description = "Commands to build and push Docker image to ECR"
   value       = <<EOF
 # ECRにログイン
-aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${aws_ecr_repository.shiritoruby.repository_url}
+aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${var.use_existing_infrastructure ? var.existing_ecr_repository_url : aws_ecr_repository.shiritoruby[0].repository_url}
 
 # 通常のDockerビルド（ローカル開発用）
 docker build -t ${var.app_name} .
-docker tag ${var.app_name}:latest ${aws_ecr_repository.shiritoruby.repository_url}:latest
-docker push ${aws_ecr_repository.shiritoruby.repository_url}:latest
+docker tag ${var.app_name}:latest ${var.use_existing_infrastructure ? var.existing_ecr_repository_url : aws_ecr_repository.shiritoruby[0].repository_url}:latest
+docker push ${var.use_existing_infrastructure ? var.existing_ecr_repository_url : aws_ecr_repository.shiritoruby[0].repository_url}:latest
 
 # マルチアーキテクチャイメージのビルドとプッシュ（本番デプロイ用）
 # Docker Buildxビルダーを作成
 docker buildx create --name mybuilder --use
 
 # マルチアーキテクチャイメージをビルドしてプッシュ
-docker buildx build --platform linux/amd64,linux/arm64 -t ${aws_ecr_repository.shiritoruby.repository_url}:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 -t ${var.use_existing_infrastructure ? var.existing_ecr_repository_url : aws_ecr_repository.shiritoruby[0].repository_url}:latest --push .
 
 # ビルダーを削除（オプション）
 # docker buildx rm mybuilder
@@ -51,10 +51,10 @@ output "db_migration_command" {
   value       = <<EOF
 # データベースマイグレーションを実行するためのECSタスクを実行
 aws ecs run-task \\
-  --cluster ${aws_ecs_cluster.main.name} \\
-  --task-definition ${aws_ecs_task_definition.app.family}:${aws_ecs_task_definition.app.revision} \\
+  --cluster ${var.use_existing_infrastructure ? var.existing_ecs_cluster_name : aws_ecs_cluster.main[0].name} \\
+  --task-definition ${var.app_name}:${var.task_definition_revision} \\
   --launch-type FARGATE \\
-  --network-configuration "awsvpcConfiguration={subnets=[${aws_subnet.private_1.id}],securityGroups=[${aws_security_group.ecs.id}],assignPublicIp=ENABLED}" \\
+  --network-configuration "awsvpcConfiguration={subnets=[${var.use_existing_infrastructure ? var.existing_public_subnet_ids[0] : aws_subnet.public_1[0].id}],securityGroups=[${var.use_existing_infrastructure ? var.existing_security_group_ids["ecs"] : aws_security_group.ecs[0].id}],assignPublicIp=ENABLED}" \\
   --overrides '{"containerOverrides": [{"name": "${var.app_name}", "command": ["./bin/rails", "db:migrate"]}]}'
 EOF
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -63,3 +63,76 @@ variable "acm_certificate_arn" {
   type        = string
   default     = ""
 }
+
+# 既存のインフラストラクチャを参照するための変数
+variable "use_existing_infrastructure" {
+  description = "Whether to use existing infrastructure"
+  type        = bool
+  default     = true
+}
+
+variable "existing_vpc_id" {
+  description = "ID of an existing VPC"
+  type        = string
+  default     = ""
+}
+
+variable "existing_public_subnet_ids" {
+  description = "IDs of existing public subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "existing_private_subnet_ids" {
+  description = "IDs of existing private subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "existing_security_group_ids" {
+  description = "IDs of existing security groups"
+  type        = map(string)
+  default     = {}
+}
+
+variable "existing_ecr_repository_url" {
+  description = "URL of an existing ECR repository"
+  type        = string
+  default     = ""
+}
+
+variable "existing_ecs_cluster_name" {
+  description = "Name of an existing ECS cluster"
+  type        = string
+  default     = ""
+}
+
+variable "existing_ecs_task_execution_role_arn" {
+  description = "ARN of an existing ECS task execution role"
+  type        = string
+  default     = ""
+}
+
+variable "existing_cloudwatch_log_group_name" {
+  description = "Name of an existing CloudWatch log group"
+  type        = string
+  default     = ""
+}
+
+variable "existing_lb_arn" {
+  description = "ARN of an existing load balancer"
+  type        = string
+  default     = ""
+}
+
+variable "existing_lb_target_group_arn" {
+  description = "ARN of an existing load balancer target group"
+  type        = string
+  default     = ""
+}
+
+variable "task_definition_revision" {
+  description = "Revision of the existing ECS task definition"
+  type        = string
+  default     = "1"  # デフォルトは1を設定
+}


### PR DESCRIPTION
## 変更の概要

- Terraformの設定を修正し、既存のインフラストラクチャを使用できるようにしました
- ECSサービスとロードバランサーの依存関係の問題を解決しました
- 出力変数を修正し、条件付きリソースを正しく参照できるようにしました

## 詳細

- `main.tf`：ECSサービスとロードバランサーの依存関係を修正し、静的なリスト式を使用するように変更
- `outputs.tf`：条件付きリソースを正しく参照するように修正
- `variables.tf`：`task_definition_revision`変数を追加
- `terraform.tfvars`：必要な変数の設定を追加
