### PR TITLE
ドメイン設定の追加（shiritoruby.link）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,8 @@ jobs:
             -var="db_username=${{ secrets.TF_VAR_DB_USERNAME }}" \
             -var="db_password=${{ secrets.TF_VAR_DB_PASSWORD }}" \
             -var="rails_master_key=${{ secrets.TF_VAR_RAILS_MASTER_KEY }}" \
-            -var="domain_name=${{ secrets.TF_VAR_DOMAIN_NAME }}" \
-            -var="create_acm_certificate=${{ secrets.TF_VAR_CREATE_ACM_CERTIFICATE || 'true' }}" \
-            -var="acm_certificate_arn=${{ secrets.TF_VAR_ACM_CERTIFICATE_ARN || '' }}"
+            -var="domain_name=${{ vars.TF_VAR_DOMAIN_NAME || '' }}" \
+            -var="create_acm_certificate=${{ secrets.TF_VAR_CREATE_ACM_CERTIFICATE || vars.TF_VAR_CREATE_ACM_CERTIFICATE || 'true' }}" \
+            -var="acm_certificate_arn=${{ secrets.TF_VAR_ACM_CERTIFICATE_ARN || vars.TF_VAR_ACM_CERTIFICATE_ARN || '' }}" \
+            -var="existing_lb_dns_name=${{ secrets.TF_VAR_EXISTING_LB_DNS_NAME || vars.TF_VAR_EXISTING_LB_DNS_NAME || '' }}" \
+            -var="existing_lb_zone_id=${{ secrets.TF_VAR_EXISTING_LB_ZONE_ID || vars.TF_VAR_EXISTING_LB_ZONE_ID || '' }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,6 +154,8 @@ jobs:
             -var="db_username=${{ secrets.TF_VAR_DB_USERNAME }}" \
             -var="db_password=${{ secrets.TF_VAR_DB_PASSWORD }}" \
             -var="rails_master_key=${{ secrets.TF_VAR_RAILS_MASTER_KEY }}" \
-            -var="domain_name=${{ secrets.TF_VAR_DOMAIN_NAME }}" \
-            -var="create_acm_certificate=${{ secrets.TF_VAR_CREATE_ACM_CERTIFICATE || 'true' }}" \
-            -var="acm_certificate_arn=${{ secrets.TF_VAR_ACM_CERTIFICATE_ARN || '' }}"
+            -var="domain_name=${{ vars.TF_VAR_DOMAIN_NAME || '' }}" \
+            -var="create_acm_certificate=${{ secrets.TF_VAR_CREATE_ACM_CERTIFICATE || vars.TF_VAR_CREATE_ACM_CERTIFICATE || 'true' }}" \
+            -var="acm_certificate_arn=${{ secrets.TF_VAR_ACM_CERTIFICATE_ARN || vars.TF_VAR_ACM_CERTIFICATE_ARN || '' }}" \
+            -var="existing_lb_dns_name=${{ secrets.TF_VAR_EXISTING_LB_DNS_NAME || vars.TF_VAR_EXISTING_LB_DNS_NAME || '' }}" \
+            -var="existing_lb_zone_id=${{ secrets.TF_VAR_EXISTING_LB_ZONE_ID || vars.TF_VAR_EXISTING_LB_ZONE_ID || '' }}"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -61,12 +61,12 @@ EOF
 
 output "route53_nameservers" {
   description = "The nameservers for the Route 53 zone"
-  value       = var.domain_name != "" ? aws_route53_zone.main.name_servers : []
+  value       = var.domain_name != "" ? (length(aws_route53_zone.main) > 0 ? aws_route53_zone.main[0].name_servers : []) : []
 }
 
 output "domain_setup_instructions" {
   description = "Instructions for setting up the domain with Route 53"
-  value       = var.domain_name != "" ? "# Route 53でのドメイン設定手順\n\n1. 以下のネームサーバーをドメインレジストラに設定してください：\n   ${join("\n   ", formatlist("- %s", aws_route53_zone.main.name_servers))}\n\n2. ネームサーバーの変更が反映されるまで、最大48時間かかる場合があります。\n\n3. DNSの伝播状況は以下のコマンドで確認できます：\n   dig ${var.domain_name} NS\n\n4. 証明書の検証が完了したら、以下のURLでアプリケーションにアクセスできます：\n   - https://${var.domain_name}\n   - https://www.${var.domain_name}" : "ドメイン名が設定されていません。"
+  value       = var.domain_name != "" ? (length(aws_route53_zone.main) > 0 ? "# Route 53でのドメイン設定手順\n\n1. 以下のネームサーバーをドメインレジストラに設定してください：\n   ${join("\n   ", formatlist("- %s", aws_route53_zone.main[0].name_servers))}\n\n2. ネームサーバーの変更が反映されるまで、最大48時間かかる場合があります。\n\n3. DNSの伝播状況は以下のコマンドで確認できます：\n   dig ${var.domain_name} NS\n\n4. 証明書の検証が完了したら、以下のURLでアプリケーションにアクセスできます：\n   - https://${var.domain_name}\n   - https://www.${var.domain_name}" : "ホストゾーンが作成されていません。") : "ドメイン名が設定されていません。"
 }
 
 output "github_actions_role_arn" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -59,6 +59,16 @@ aws ecs run-task \\
 EOF
 }
 
+output "route53_nameservers" {
+  description = "The nameservers for the Route 53 zone"
+  value       = var.domain_name != "" ? aws_route53_zone.main.name_servers : []
+}
+
+output "domain_setup_instructions" {
+  description = "Instructions for setting up the domain with Route 53"
+  value       = var.domain_name != "" ? "# Route 53でのドメイン設定手順\n\n1. 以下のネームサーバーをドメインレジストラに設定してください：\n   ${join("\n   ", formatlist("- %s", aws_route53_zone.main.name_servers))}\n\n2. ネームサーバーの変更が反映されるまで、最大48時間かかる場合があります。\n\n3. DNSの伝播状況は以下のコマンドで確認できます：\n   dig ${var.domain_name} NS\n\n4. 証明書の検証が完了したら、以下のURLでアプリケーションにアクセスできます：\n   - https://${var.domain_name}\n   - https://www.${var.domain_name}" : "ドメイン名が設定されていません。"
+}
+
 output "github_actions_role_arn" {
   description = "The ARN of the IAM role for GitHub Actions OIDC"
   value       = aws_iam_role.github_actions.arn

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,5 +1,7 @@
 # Route 53 ホストゾーン
 resource "aws_route53_zone" "main" {
+  count = var.domain_name != "" ? 1 : 0
+
   name = var.domain_name
 
   tags = {
@@ -11,7 +13,7 @@ resource "aws_route53_zone" "main" {
 resource "aws_route53_record" "cert_validation" {
   count = var.create_acm_certificate && var.domain_name != "" ? length(aws_acm_certificate.cert[0].domain_validation_options) : 0
 
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.main[0].zone_id
   name    = element(aws_acm_certificate.cert[0].domain_validation_options.*.resource_record_name, count.index)
   type    = element(aws_acm_certificate.cert[0].domain_validation_options.*.resource_record_type, count.index)
   records = [element(aws_acm_certificate.cert[0].domain_validation_options.*.resource_record_value, count.index)]
@@ -30,7 +32,7 @@ resource "aws_acm_certificate_validation" "cert" {
 resource "aws_route53_record" "alb" {
   count = var.domain_name != "" ? 1 : 0
 
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.main[0].zone_id
   name    = var.domain_name
   type    = "A"
 
@@ -45,7 +47,7 @@ resource "aws_route53_record" "alb" {
 resource "aws_route53_record" "www" {
   count = var.domain_name != "" ? 1 : 0
 
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.main[0].zone_id
   name    = "www.${var.domain_name}"
   type    = "A"
 

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,57 @@
+# Route 53 ホストゾーン
+resource "aws_route53_zone" "main" {
+  name = var.domain_name
+
+  tags = {
+    Name = "${var.app_name}-zone"
+  }
+}
+
+# ACM証明書のDNS検証レコード
+resource "aws_route53_record" "cert_validation" {
+  count = var.create_acm_certificate && var.domain_name != "" ? length(aws_acm_certificate.cert[0].domain_validation_options) : 0
+
+  zone_id = aws_route53_zone.main.zone_id
+  name    = element(aws_acm_certificate.cert[0].domain_validation_options.*.resource_record_name, count.index)
+  type    = element(aws_acm_certificate.cert[0].domain_validation_options.*.resource_record_type, count.index)
+  records = [element(aws_acm_certificate.cert[0].domain_validation_options.*.resource_record_value, count.index)]
+  ttl     = 60
+}
+
+# ACM証明書の検証完了を待機
+resource "aws_acm_certificate_validation" "cert" {
+  count = var.create_acm_certificate && var.domain_name != "" ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.cert[0].arn
+  validation_record_fqdns = aws_route53_record.cert_validation.*.fqdn
+}
+
+# ALBへのエイリアスレコード
+resource "aws_route53_record" "alb" {
+  count = var.domain_name != "" ? 1 : 0
+
+  zone_id = aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = var.use_existing_infrastructure ? var.existing_lb_dns_name : aws_lb.main[0].dns_name
+    zone_id                = var.use_existing_infrastructure ? var.existing_lb_zone_id : aws_lb.main[0].zone_id
+    evaluate_target_health = true
+  }
+}
+
+# www サブドメインのエイリアスレコード
+resource "aws_route53_record" "www" {
+  count = var.domain_name != "" ? 1 : 0
+
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "www.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = var.use_existing_infrastructure ? var.existing_lb_dns_name : aws_lb.main[0].dns_name
+    zone_id                = var.use_existing_infrastructure ? var.existing_lb_zone_id : aws_lb.main[0].zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -87,3 +87,15 @@ variable "task_definition_revision" {
   type        = string
   default     = "1"
 }
+
+variable "existing_lb_dns_name" {
+  description = "DNS name of an existing load balancer"
+  type        = string
+  default     = ""
+}
+
+variable "existing_lb_zone_id" {
+  description = "Route 53 zone ID of an existing load balancer"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## 変更の概要

- Route 53の設定を追加（shiritoruby.link ドメイン）
- ACM証明書の設定を追加
- ALBのHTTPSリスナー設定を修正
- 関連する変数と出力を追加

## 詳細

### 追加したファイル
- terraform/route53.tf: Route 53のホストゾーン、DNSレコード、ACM証明書の検証設定

### 修正したファイル
- terraform/alb.tf: HTTPSリスナーの設定を修正
- terraform/variables.tf: ドメイン関連の変数を追加
- terraform/outputs.tf: Route 53関連の出力を追加

## 注意事項

DNSの伝播が完了するまで、最大48時間かかる場合があります。以下の手順で確認できます：

1.  `dig NS shiritoruby.link` コマンドを実行して、ネームサーバーが以下に変わったことを確認：
   - ns-1131.awsdns-13.org
   - ns-172.awsdns-21.com
   - ns-2004.awsdns-58.co.uk
   - ns-746.awsdns-29.net

2. DNSの伝播が完了したら、ACM証明書の検証も自動的に完了します：
```
aws acm describe-certificate --certificate-arn $(aws acm list-certificates --query "CertificateSummaryList[?DomainName=='shiritoruby.link'].CertificateArn" --output text) --query "Certificate.Status"
```

結果が「ISSUED」になったら、証明書の検証が完了しています。

3. 証明書の検証が完了したら、以下のURLでアプリケーションにアクセスできるようになります：
- https://shiritoruby.link
- https://www.shiritoruby.link