### PR TITLE
インフラストラクチャの設定を修正

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -80,7 +80,7 @@ resource "aws_cloudwatch_log_group" "app" {
 resource "aws_ecs_service" "app" {
   name            = "${var.app_name}-service"
   cluster         = aws_ecs_cluster.main.id
-  task_definition = "${aws_ecs_task_definition.app.arn}:${var.task_definition_revision}"
+  task_definition = aws_ecs_task_definition.app.arn
   desired_count   = var.app_count
   launch_type     = "FARGATE"
 

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -2,7 +2,7 @@
 resource "aws_secretsmanager_secret" "rails_master_key" {
   count = var.use_existing_infrastructure ? 0 : 1
 
-  name        = "${var.app_name}/RAILS_MASTER_KEY"
+  name        = "${var.app_name}/RAILS_MASTER_KEY_NEW"
   description = "Rails Master Key for ${var.app_name}"
 }
 
@@ -16,7 +16,7 @@ resource "aws_secretsmanager_secret_version" "rails_master_key" {
 resource "aws_secretsmanager_secret" "database_url" {
   count = var.use_existing_infrastructure ? 0 : 1
 
-  name        = "${var.app_name}/DATABASE_URL"
+  name        = "${var.app_name}/DATABASE_URL_NEW"
   description = "Database URL for ${var.app_name}"
 }
 


### PR DESCRIPTION
## 変更の概要

- シークレットの名前を変更して削除予定のシークレットとの競合を回避
- ECSタスク定義のリビジョン番号の問題を解決

## 詳細

### 修正した問題
1. Secrets Managerのシークレットが削除予定であるため、新しいシークレットを作成できない問題を解決
   - シークレットの名前を変更（`RAILS_MASTER_KEY` → `RAILS_MASTER_KEY_NEW`、`DATABASE_URL` → `DATABASE_URL_NEW`）

2. ECSサービスのタスク定義のリビジョン番号の問題を解決
   - リビジョン番号を指定する代わりに、最新のリビジョンを使用するように修正

### 結果
これらの修正により、インフラストラクチャの正常なデプロイが可能になり、ドメイン「shiritoruby.link」でアプリケーションにアクセスできるようになりました。