### PR TITLE
Fix: セッションマネージャー初期化時の不要なゲーム作成を防止

### DIFF
--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -129,7 +129,8 @@ class Api::GamesController < ApplicationController
     end
 
     # 既存のゲームからセッションマネージャーを再構築
-    @session_manager = Games::SessionManager.new(game.player_name)
+    # create_game_flag = false を指定して新しいゲームが作成されないようにする
+    @session_manager = Games::SessionManager.new(game.player_name, 10, false)
     @session_manager.instance_variable_set(:@game, game)
     @session_manager.instance_variable_set(:@start_time, game.created_at)
 

--- a/app/services/games/session_manager.rb
+++ b/app/services/games/session_manager.rb
@@ -23,14 +23,15 @@ module Games
     # 新しいゲームセッションを初期化
     # @param player_name [String] プレイヤー名
     # @param time_limit [Integer] 制限時間（秒）
-    def initialize(player_name, time_limit = 10)
+    # @param create_game_flag [Boolean] ゲームを作成するかどうか
+    def initialize(player_name, time_limit = 10, create_game_flag = true)
       @player_name = player_name
       @time_limit = time_limit
       @current_state = GAME_STATE[:waiting_for_player]
       @used_words = []
       @end_reason = nil
       @start_time = Time.current
-      create_game
+      create_game if create_game_flag
     end
 
     # ゲームを作成し、初期化する

--- a/app/services/games/session_service.rb
+++ b/app/services/games/session_service.rb
@@ -100,7 +100,8 @@ module Games
       end
 
       # 既存のゲームからセッションマネージャーを再構築
-      session_manager = Games::SessionManager.new(game.player_name)
+      # create_game_flag = false を指定して新しいゲームが作成されないようにする
+      session_manager = Games::SessionManager.new(game.player_name, 10, false)
       session_manager.instance_variable_set(:@game, game)
       session_manager.instance_variable_set(:@start_time, game.created_at)
 


### PR DESCRIPTION
## 変更の概要

- Games::SessionManagerのinitializeメソッドにcreate_game_flagパラメータを追加
- 既存のゲームからセッションマネージャーを再構築する際にcreate_game_flag=falseを指定

## 詳細

1ゲームでランキングが4レコード増える問題を修正しました。問題の原因は、セッションマネージャーの初期化時に新しいゲームが自動的に作成されることでした。

具体的には、以下のような流れで問題が発生していました：

1. ユーザーがゲームを開始すると、`Api::GamesController#create`アクションが呼び出され、`Games::SessionManager.new(player_name)`を実行して新しいゲームが作成される
2. ゲームの途中でAPIリクエスト（例：単語の提出）を送信すると、`set_session_manager`メソッドが呼び出され、`Games::SessionManager.new(game.player_name)`を実行して新しいゲームが作成される
3. その後、既存のゲームを設定するが、この時点で既に新しいゲームが作成されている
4. 結果として、1回のゲームプレイで複数のゲームレコードが作成される

この修正により、ゲーム開始時にのみ新しいゲームが作成され、その後のAPIリクエストでは既存のゲームが使用されるようになります。