### PR TITLE
Fix: UIモジュールがテーブルを返すように修正

### DIFF
--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -129,7 +129,8 @@ class Api::GamesController < ApplicationController
     end
 
     # 既存のゲームからセッションマネージャーを再構築
-    @session_manager = Games::SessionManager.new(game.player_name)
+    # create_game_flag = false を指定して新しいゲームが作成されないようにする
+    @session_manager = Games::SessionManager.new(game.player_name, 10, false)
     @session_manager.instance_variable_set(:@game, game)
     @session_manager.instance_variable_set(:@start_time, game.created_at)
 

--- a/app/services/games/session_manager.rb
+++ b/app/services/games/session_manager.rb
@@ -23,14 +23,15 @@ module Games
     # 新しいゲームセッションを初期化
     # @param player_name [String] プレイヤー名
     # @param time_limit [Integer] 制限時間（秒）
-    def initialize(player_name, time_limit = 10)
+    # @param create_game_flag [Boolean] ゲームを作成するかどうか
+    def initialize(player_name, time_limit = 10, create_game_flag = true)
       @player_name = player_name
       @time_limit = time_limit
       @current_state = GAME_STATE[:waiting_for_player]
       @used_words = []
       @end_reason = nil
       @start_time = Time.current
-      create_game
+      create_game if create_game_flag
     end
 
     # ゲームを作成し、初期化する

--- a/app/services/games/session_service.rb
+++ b/app/services/games/session_service.rb
@@ -100,7 +100,8 @@ module Games
       end
 
       # 既存のゲームからセッションマネージャーを再構築
-      session_manager = Games::SessionManager.new(game.player_name)
+      # create_game_flag = false を指定して新しいゲームが作成されないようにする
+      session_manager = Games::SessionManager.new(game.player_name, 10, false)
       session_manager.instance_variable_set(:@game, game)
       session_manager.instance_variable_set(:@start_time, game.created_at)
 


### PR DESCRIPTION
## 問題点

`:SlackChannels`を実行すると以下のエラーが発生していました：
Error executing vim.schedule lua callback: ...al/share/nvim/lazy/neo-slack.nvim/lua/neo-slack/init.lua:246: attempt to index upvalue 'ui' (a boolean value)


## 原因

`lua/neo-slack/ui.lua`ファイルの最後に`return M`が欠けていたため、モジュールがテーブルを返していませんでした。そのため、`init.lua`で`ui`変数がブール値として扱われ、`ui.show_channels(channels)`でエラーが発生していました。

## 修正内容

`ui.lua`ファイルの最後に`return M`を追加し、モジュールが正しくテーブルを返すようにしました。これにより、`ui.show_channels(channels)`が正常に動作するようになります。