### PR TITLE
アプリケーションのタイムゾーンを日本時間（JST）に設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,12 @@ module Shiritoruby
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    # タイムゾーンを日本時間（JST）に設定
+    config.time_zone = "Tokyo"
+
+    # データベースの時間はUTCのまま（Railsのベストプラクティス）
+    config.active_record.default_timezone = :utc
+
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
## 変更の概要

- アプリケーションのタイムゾーンを日本時間（JST）に設定
- データベースの時間はUTCのまま（Railsのベストプラクティス）

## 詳細

- にタイムゾーン設定を追加
  - でアプリケーションのタイムゾーンを日本時間に設定
  - でデータベースの時間はUTCのまま保持
- テストとRubocopが全て通過することを確認済み