### PR TITLE
本番環境のコンソールアクセスのためにECS Execを有効化

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -26,6 +26,7 @@ resource "aws_ecs_task_definition" "app" {
   cpu                      = var.task_cpu
   memory                   = var.task_memory
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
 
   container_definitions = jsonencode([
     {
@@ -83,6 +84,7 @@ resource "aws_ecs_service" "app" {
   task_definition = aws_ecs_task_definition.app.arn
   desired_count   = var.app_count
   launch_type     = "FARGATE"
+  enable_execute_command = true
 
   network_configuration {
     security_groups  = var.use_existing_infrastructure ? [] : [aws_security_group.ecs[0].id]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -51,3 +51,49 @@ resource "aws_iam_role_policy_attachment" "secrets_access" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = aws_iam_policy.secrets_access[0].arn
 }
+
+# ECS Execを有効にするためのタスクロール
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.app_name}-ecs-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# ECS Execを有効にするためのポリシー
+resource "aws_iam_policy" "ecs_exec_policy" {
+  name        = "${var.app_name}-ecs-exec-policy"
+  description = "Allow ECS Exec functionality"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# タスクロールにECS Execポリシーをアタッチ
+resource "aws_iam_role_policy_attachment" "ecs_exec_policy_attachment" {
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = aws_iam_policy.ecs_exec_policy.arn
+}


### PR DESCRIPTION
## 変更の概要

- 本番環境のRailsコンソールにアクセスするためにECS Execを有効化
- ECSタスクロールとECS Exec用のIAMポリシーを追加
- ECSサービスでExecute Commandを有効化

## 詳細

本番環境のRailsコンソールにアクセスするために、AWS ECS Execを有効にしました。これにより、以下のコマンドで本番環境のコンソールに安全にアクセスできるようになります（zsh対応）：

```bash
# SessionManagerPluginのインストール（初回のみ）
curl 'https://s3.amazonaws.com/session-manager-downloads/plugin/latest/mac/sessionmanager-bundle.zip' -o 'sessionmanager-bundle.zip'
unzip sessionmanager-bundle.zip
sudo ./sessionmanager-bundle/install -i /usr/local/sessionmanagerplugin -b /usr/local/bin/session-manager-plugin

# ECS Execを使用してコンソールにアクセス
AWS_PROFILE=shiritoruby aws ecs list-tasks --cluster shiritoruby-cluster
# タスクIDを環境変数に設定（例）
TASK_ID=0266ec60bbdd4c86bb9b0f6ad2016af3
# コンテナに接続
AWS_PROFILE=shiritoruby aws ecs execute-command --cluster shiritoruby-cluster --task  --container shiritoruby --interactive --command '/bin/bash'
# コンテナ内でRailsコンソールを起動
cd /rails
bin/rails console
```