### PR TITLE
単語管理ページの追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
 
+# ファイル末尾の改行チェックを無効化
+Layout/TrailingEmptyLines:
+  Enabled: false
+
 # JavaScriptファイルを検査から除外
 AllCops:
   Exclude:

--- a/app/assets/stylesheets/words.css
+++ b/app/assets/stylesheets/words.css
@@ -1,0 +1,170 @@
+/* 単語管理ページのスタイル */
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.card {
+  margin-bottom: 2rem;
+  border: 1px solid var(--light-gray);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.card-header {
+  background-color: var(--light-gray);
+  padding: 0.75rem 1rem;
+  border-bottom: 2px solid var(--primary-color);
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--primary-color);
+}
+
+.card-body {
+  padding: 1.5rem;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin: -0.75rem;
+}
+
+.col-md-6 {
+  flex: 0 0 50%;
+  max-width: 50%;
+  padding: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .col-md-6 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+}
+
+.mb-3 {
+  margin-bottom: 1rem;
+}
+
+.mb-4 {
+  margin-bottom: 1.5rem;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.form-control {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid var(--light-gray);
+  border-radius: 4px;
+}
+
+.btn {
+  display: inline-block;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  user-select: none;
+  border: 1px solid transparent;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 4px;
+  transition: all 0.15s ease-in-out;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.btn-primary {
+  color: #fff;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
+.btn-primary:hover {
+  background-color: var(--secondary-color);
+  border-color: var(--secondary-color);
+}
+
+.btn-success {
+  color: #fff;
+  background-color: var(--accent-color);
+  border-color: var(--accent-color);
+}
+
+.btn-success:hover {
+  background-color: #218838;
+  border-color: #1e7e34;
+}
+
+.table-responsive {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table {
+  width: 100%;
+  margin-bottom: 1rem;
+  color: var(--text-color);
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem;
+  vertical-align: top;
+  border-bottom: 1px solid var(--light-gray);
+}
+
+.table thead th {
+  vertical-align: bottom;
+  border-bottom: 2px solid var(--primary-color);
+  background-color: var(--light-gray);
+  font-weight: bold;
+}
+
+.table-striped tbody tr:nth-of-type(odd) {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.table-hover tbody tr:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+pre {
+  background-color: #f8f9fa;
+  padding: 0.75rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  overflow-x: auto;
+}
+
+.d-flex {
+  display: flex;
+}
+
+.justify-content-center {
+  justify-content: center;
+}
+
+.mt-4 {
+  margin-top: 1.5rem;
+}

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -1,0 +1,103 @@
+class WordsController < ApplicationController
+  require 'csv'
+
+  def index
+    @words = Word.all.order(:word).page(params[:page]).per(50)
+  end
+
+  def download
+    @words = Word.all.order(:word)
+
+    respond_to do |format|
+      format.csv do
+        csv_data = CSV.generate(headers: true) do |csv|
+          # ヘッダー行
+          csv << ["word", "word_type", "description"]
+
+          # データ行
+          @words.each do |word|
+            csv << [word.word, word.word_type, word.description]
+          end
+        end
+
+        send_data csv_data, filename: "words_#{Time.current.strftime('%Y%m%d%H%M%S')}.csv"
+      end
+    end
+  end
+
+  def upload
+    if params[:file].blank?
+      flash[:alert] = "ファイルを選択してください"
+      redirect_to words_path
+      return
+    end
+
+    # CSVファイルかどうかのチェック
+    content_type = params[:file].respond_to?(:content_type) ? params[:file].content_type : nil
+    filename = params[:file].respond_to?(:original_filename) ? params[:file].original_filename : File.basename(params[:file].path)
+
+    unless content_type == "text/csv" || filename.end_with?(".csv")
+      flash[:alert] = "CSVファイルのみアップロード可能です"
+      redirect_to words_path
+      return
+    end
+
+    begin
+      added_count = 0
+      skipped_count = 0
+      errors = []
+
+      # ファイルの内容を読み込む
+      file_content = File.read(params[:file].path)
+
+      # CSVパース
+      csv_data = CSV.parse(file_content, headers: true)
+
+      # 各行を処理
+      csv_data.each do |row|
+        word_text = row["word"]
+
+        # 単語が空の場合はスキップ
+        if word_text.blank?
+          skipped_count += 1
+          next
+        end
+
+        # 単語が既に存在する場合はスキップ
+        if Word.exists?(word: word_text)
+          skipped_count += 1
+          next
+        end
+
+        # 単語データを作成
+        word_data = {
+          word: word_text,
+          normalized_word: word_text.downcase, # normalized_wordを明示的に設定
+          word_type: row["word_type"] || "method",
+          description: row["description"]
+        }
+
+        # 単語を登録
+        word = Word.new(word_data)
+        if word.save
+          added_count += 1
+        else
+          errors << "#{word_data[:word]}: #{word.errors.full_messages.join(', ')}"
+          skipped_count += 1
+        end
+      end
+
+      if errors.any?
+        flash[:alert] = "#{added_count}件の単語を追加しました。#{skipped_count}件の単語をスキップしました。エラー: #{errors.join(', ')}"
+      else
+        flash[:notice] = "#{added_count}件の単語を追加しました。#{skipped_count}件の単語をスキップしました。"
+      end
+    rescue CSV::MalformedCSVError => e
+      flash[:alert] = "CSVファイルの形式が不正です: #{e.message}"
+    rescue => e
+      flash[:alert] = "エラーが発生しました: #{e.message}"
+    end
+
+    redirect_to words_path
+  end
+end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -1,5 +1,5 @@
 class WordsController < ApplicationController
-  require 'csv'
+  require "csv"
 
   def index
     @words = Word.all.order(:word).page(params[:page]).per(50)

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -82,6 +82,7 @@
     </form>
     <div class="view-rankings">
       <a href="<%= rankings_path %>" class="rankings-link">ランキングを見る</a>
+      <a href="<%= words_path %>" class="rankings-link">単語管理</a>
     </div>
   </div>
 

--- a/app/views/games/rankings.html.erb
+++ b/app/views/games/rankings.html.erb
@@ -9,6 +9,7 @@
   <div class="ranking-content">
     <div class="ranking-nav">
       <a href="<%= root_path %>" class="back-to-game">ゲームに戻る</a>
+      <a href="<%= words_path %>" class="back-to-game">単語管理</a>
 
       <!-- フィルターとソートのフォーム -->
       <div class="ranking-filter">

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -1,0 +1,76 @@
+<% content_for :title, "Shiritoruby - 単語管理" %>
+
+<div class="container">
+  <header class="game-header">
+    <h1>ShiritoRuby</h1>
+    <p class="subtitle">単語管理</p>
+  </header>
+
+  <div class="ranking-nav">
+    <a href="<%= root_path %>" class="back-to-game">ゲームに戻る</a>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      <h2>CSVファイル操作</h2>
+    </div>
+    <div class="card-body">
+      <div class="row">
+        <div class="col-md-6">
+          <h3>単語データのダウンロード</h3>
+          <p>現在登録されている単語データをCSVファイルでダウンロードできます。</p>
+          <%= link_to "CSVダウンロード", download_words_path(format: :csv), class: "btn btn-primary" %>
+        </div>
+
+        <div class="col-md-6">
+          <h3>単語データのアップロード</h3>
+          <p>CSVファイルから単語データを一括登録できます。</p>
+          <p>CSVファイルは以下の形式で作成してください：</p>
+          <pre>word,word_type,description
+example,method,This is an example method
+keyword_example,keyword,This is a keyword example</pre>
+
+          <%= form_with url: upload_words_path, method: :post, local: true, multipart: true do |form| %>
+            <div class="mb-3">
+              <%= form.label :file, "CSVファイル", class: "form-label" %>
+              <%= form.file_field :file, accept: "text/csv", class: "form-control" %>
+            </div>
+            <%= form.submit "アップロード", class: "btn btn-success" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header">
+      <h2>登録済み単語一覧</h2>
+    </div>
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-striped table-hover">
+          <thead>
+            <tr>
+              <th>単語</th>
+              <th>種類</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @words.each do |word| %>
+              <tr>
+                <td><%= word.word %></td>
+                <td><%= word.word_type %></td>
+                <td><%= word.description %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="d-flex justify-content-center mt-4">
+        <%= paginate @words %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,14 @@ Rails.application.routes.draw do
     end
   end
 
+  # Words management route
+  resources :words, only: [:index] do
+    collection do
+      get :download
+      post :upload
+    end
+  end
+
   # Ranking route
   get "rankings", to: "games#rankings"
 

--- a/spec/controllers/words_controller_spec.rb
+++ b/spec/controllers/words_controller_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe WordsController, type: :controller do
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+
+    it "responds successfully" do
+      word1 = create(:word, word: "example1")
+      word2 = create(:word, word: "example2")
+      get :index
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #download" do
+    it "returns a CSV file" do
+      create(:word, word: "csv_test1", word_type: "method", description: "CSV Test 1")
+      get :download, format: :csv
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("text/csv")
+      expect(response.headers["Content-Disposition"]).to include("attachment")
+      expect(response.headers["Content-Disposition"]).to include(".csv")
+    end
+
+    it "includes all words in the CSV" do
+      word1 = create(:word, word: "csv_test2", word_type: "method", description: "CSV Test 2")
+      word2 = create(:word, word: "csv_test3", word_type: "keyword", description: "CSV Test 3")
+      get :download, format: :csv
+
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.count).to be >= 2
+
+      # 単語の順序に依存しないテスト
+      words_in_csv = csv.map { |row| row["word"] }
+      expect(words_in_csv).to include(word1.word)
+      expect(words_in_csv).to include(word2.word)
+
+      # 各単語の詳細情報が正しく含まれているか確認
+      word1_row = csv.find { |row| row["word"] == word1.word }
+      expect(word1_row["word_type"]).to eq(word1.word_type)
+      expect(word1_row["description"]).to eq(word1.description)
+
+      word2_row = csv.find { |row| row["word"] == word2.word }
+      expect(word2_row["word_type"]).to eq(word2.word_type)
+      expect(word2_row["description"]).to eq(word2.description)
+    end
+  end
+
+  describe "POST #upload" do
+    context "with valid CSV file" do
+      it "adds new words from the CSV file" do
+        # CSVファイルを作成
+        file_path = Rails.root.join('tmp', 'test_upload.csv')
+        File.write(file_path, "word,word_type,description\nupload_test1,method,Uploaded test word\nupload_test2,keyword,Uploaded test keyword")
+
+        # ファイルをアップロード
+        file = fixture_file_upload(file_path, 'text/csv')
+
+        # テスト実行
+        expect {
+          post :upload, params: { file: file }
+        }.to change(Word, :count).by(2)
+
+        # 結果確認
+        expect(Word.find_by(word: "upload_test1")).to be_present
+        expect(Word.find_by(word: "upload_test2")).to be_present
+
+        # ファイル削除
+        File.delete(file_path) if File.exist?(file_path)
+      end
+
+      it "redirects to words_path with a success message" do
+        # CSVファイルを作成
+        file_path = Rails.root.join('tmp', 'test_upload2.csv')
+        File.write(file_path, "word,word_type,description\nupload_test3,method,Uploaded test word\nupload_test4,keyword,Uploaded test keyword")
+
+        # ファイルをアップロード
+        file = fixture_file_upload(file_path, 'text/csv')
+
+        # テスト実行
+        post :upload, params: { file: file }
+
+        # 結果確認
+        expect(response).to redirect_to(words_path)
+        expect(flash[:notice]).to include("2件の単語を追加しました")
+
+        # ファイル削除
+        File.delete(file_path) if File.exist?(file_path)
+      end
+
+      it "skips existing words" do
+        # 既存の単語を作成
+        create(:word, word: "upload_test5")
+
+        # CSVファイルを作成
+        file_path = Rails.root.join('tmp', 'test_upload3.csv')
+        File.write(file_path, "word,word_type,description\nupload_test5,method,Uploaded test word\nupload_test6,keyword,Uploaded test keyword")
+
+        # ファイルをアップロード
+        file = fixture_file_upload(file_path, 'text/csv')
+
+        # テスト実行
+        expect {
+          post :upload, params: { file: file }
+        }.to change(Word, :count).by(1)
+
+        # 結果確認
+        expect(flash[:notice]).to include("1件の単語を追加しました")
+        expect(flash[:notice]).to include("1件の単語をスキップしました")
+
+        # ファイル削除
+        File.delete(file_path) if File.exist?(file_path)
+      end
+    end
+
+    context "with invalid parameters" do
+      it "redirects with an error when no file is provided" do
+        post :upload
+        expect(response).to redirect_to(words_path)
+        expect(flash[:alert]).to include("ファイルを選択してください")
+      end
+
+      it "redirects with an error when non-CSV file is provided" do
+        file = fixture_file_upload(
+          Rails.root.join('spec', 'rails_helper.rb'),
+          'text/plain'
+        )
+
+        post :upload, params: { file: file }
+        expect(response).to redirect_to(words_path)
+        expect(flash[:alert]).to include("CSVファイルのみアップロード可能です")
+      end
+    end
+  end
+end

--- a/spec/system/words_spec.rb
+++ b/spec/system/words_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe "Words", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  describe "単語管理ページ" do
+    before do
+      # テスト用の単語を作成
+      create(:word, word: "example", word_type: "method", description: "Example method")
+      create(:word, word: "test", word_type: "keyword", description: "Test keyword")
+
+      visit words_path
+    end
+
+    it "単語一覧が表示される" do
+      expect(page).to have_content("単語管理")
+      expect(page).to have_content("登録済み単語一覧")
+
+      expect(page).to have_content("example")
+      expect(page).to have_content("method")
+      expect(page).to have_content("Example method")
+
+      expect(page).to have_content("test")
+      expect(page).to have_content("keyword")
+      expect(page).to have_content("Test keyword")
+    end
+
+    it "CSVダウンロードリンクが表示される" do
+      expect(page).to have_link("CSVダウンロード", href: download_words_path(format: :csv))
+    end
+
+    it "CSVアップロードフォームが表示される" do
+      expect(page).to have_content("単語データのアップロード")
+      expect(page).to have_field("file")
+      expect(page).to have_button("アップロード")
+    end
+  end
+
+  describe "CSVアップロード機能", js: false do
+    before do
+      visit words_path
+
+      # CSVファイルを作成
+      @file_path = Rails.root.join('tmp', 'system_test_upload.csv')
+      File.write(@file_path, "word,word_type,description\nsystem_test1,method,System test method\nsystem_test2,keyword,System test keyword")
+    end
+
+    after do
+      # テスト用のCSVファイルを削除
+      File.delete(@file_path) if File.exist?(@file_path)
+    end
+
+    it "CSVファイルをアップロードして単語を追加できる" do
+      # 単語数を記録
+      initial_count = Word.count
+
+      # CSVファイルをアップロード
+      attach_file("file", @file_path)
+      click_button "アップロード"
+
+      # 単語が追加されたことを確認
+      expect(Word.count).to eq(initial_count + 2)
+
+      # 追加された単語が表示されていることを確認
+      expect(page).to have_content("system_test1")
+      expect(page).to have_content("method")
+      expect(page).to have_content("System test method")
+
+      expect(page).to have_content("system_test2")
+      expect(page).to have_content("keyword")
+      expect(page).to have_content("System test keyword")
+    end
+  end
+end


### PR DESCRIPTION
## 変更の概要

- 単語管理ページ（/words）を追加
- 登録済み単語リストをCSVファイルでダウンロードする機能を実装
- CSVファイルをアップロードして単語を一括登録する機能を実装
- ゲーム画面とランキング画面に単語管理ページへのリンクを追加

## 詳細

- WordsControllerを作成し、index, download, uploadアクションを実装
- 単語管理ページのビューとスタイルを作成
- コントローラーテストとシステムテストを実装

![Uploading 2025-04-16 14.28.32.gif…]()
