### PR TITLE
単語管理ページに検索機能と削除機能を追加

### DIFF
--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -2,7 +2,27 @@ class WordsController < ApplicationController
   require "csv"
 
   def index
-    @words = Word.all.order(:word).page(params[:page]).per(50)
+    @query = params[:query]
+    @words = Word.all
+
+    # 検索クエリがある場合は絞り込み
+    if @query.present?
+      @words = @words.where("word LIKE ? OR description LIKE ?", "%#{@query}%", "%#{@query}%")
+    end
+
+    @words = @words.order(:word).page(params[:page]).per(50)
+  end
+
+  def destroy
+    @word = Word.find(params[:id])
+
+    if @word.destroy
+      flash[:notice] = "単語「#{@word.word}」を削除しました。"
+    else
+      flash[:alert] = "単語の削除に失敗しました。"
+    end
+
+    redirect_to words_path
   end
 
   def download

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -47,6 +47,19 @@ keyword_example,keyword,This is a keyword example</pre>
       <h2>登録済み単語一覧</h2>
     </div>
     <div class="card-body">
+      <!-- 検索フォーム -->
+      <div class="search-form mb-4">
+        <%= form_with url: words_path, method: :get, local: true, class: "d-flex" do |form| %>
+          <div class="input-group">
+            <%= form.text_field :query, value: @query, placeholder: "単語または説明を検索", class: "form-control" %>
+            <button type="submit" class="btn btn-primary">検索</button>
+            <% if @query.present? %>
+              <%= link_to "クリア", words_path, class: "btn btn-outline-secondary" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+
       <div class="table-responsive">
         <table class="table table-striped table-hover">
           <thead>
@@ -54,14 +67,27 @@ keyword_example,keyword,This is a keyword example</pre>
               <th>単語</th>
               <th>種類</th>
               <th>説明</th>
+              <th>操作</th>
             </tr>
           </thead>
           <tbody>
-            <% @words.each do |word| %>
+            <% if @words.any? %>
+              <% @words.each do |word| %>
+                <tr>
+                  <td><%= word.word %></td>
+                  <td><%= word.word_type %></td>
+                  <td><%= word.description %></td>
+                  <td>
+                    <%= link_to "削除", word_path(word),
+                        method: :delete,
+                        data: { turbo_method: :delete, turbo_confirm: "単語「#{word.word}」を削除してもよろしいですか？" },
+                        class: "btn btn-sm btn-danger" %>
+                  </td>
+                </tr>
+              <% end %>
+            <% else %>
               <tr>
-                <td><%= word.word %></td>
-                <td><%= word.word_type %></td>
-                <td><%= word.description %></td>
+                <td colspan="4" class="text-center">単語が見つかりません</td>
               </tr>
             <% end %>
           </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   end
 
   # Words management route
-  resources :words, only: [:index] do
+  resources :words, only: [:index, :destroy] do
     collection do
       get :download
       post :upload

--- a/spec/system/words_spec.rb
+++ b/spec/system/words_spec.rb
@@ -73,4 +73,74 @@ RSpec.describe "Words", type: :system do
       expect(page).to have_content("System test keyword")
     end
   end
+
+  describe "検索機能", js: false do
+    before do
+      # テスト用の単語を作成
+      @word1 = create(:word, word: "search_word", description: "This is a searchable word")
+      @word2 = create(:word, word: "another_word", description: "This is another word")
+      @word3 = create(:word, word: "third_word", description: "Contains search term")
+
+      visit words_path
+    end
+
+    it "単語を検索できる" do
+      # 検索フォームに入力
+      fill_in "query", with: "search"
+      click_button "検索"
+
+      # 検索結果を確認
+      expect(page).to have_content(@word1.word)
+      expect(page).to have_content(@word3.description)
+      expect(page).not_to have_content(@word2.word)
+
+      # 検索クエリがフォームに残っていることを確認
+      expect(find_field("query").value).to eq("search")
+
+      # クリアボタンが表示されていることを確認
+      expect(page).to have_link("クリア")
+    end
+
+    it "検索結果をクリアできる" do
+      # 検索を実行
+      fill_in "query", with: "search"
+      click_button "検索"
+
+      # クリアボタンをクリック
+      click_link "クリア"
+
+      # すべての単語が表示されていることを確認
+      expect(page).to have_content(@word1.word)
+      expect(page).to have_content(@word2.word)
+      expect(page).to have_content(@word3.word)
+
+      # 検索フォームがクリアされていることを確認（値の検証ではなく、フィールドの存在を確認）
+      expect(page).to have_field("query")
+      # クエリパラメータがないことを確認
+      expect(current_url).not_to include("query=")
+    end
+  end
+
+  describe "削除機能", js: false do
+    before do
+      @word = create(:word, word: "delete_test", description: "This word will be deleted")
+      visit words_path
+    end
+
+    it "単語を削除できる" do
+      # 削除前の単語数を記録
+      initial_count = Word.count
+
+      # 削除リンクのパスを直接取得して削除リクエストを送信
+      delete_path = word_path(@word)
+      page.driver.submit :delete, delete_path, {}
+
+      # 削除後のページを表示
+      visit words_path
+
+      # 単語が削除されたことを確認
+      expect(Word.count).to eq(initial_count - 1)
+      expect(page).not_to have_content(@word.word)
+    end
+  end
 end


### PR DESCRIPTION
## 変更の概要

- 単語管理ページに検索機能を追加
- 単語管理ページに削除機能を追加

## 詳細

- 単語または説明文で検索できる機能を実装
- 検索結果をクリアできる機能を実装
- 一覧から1単語を削除できる機能を実装
- コントローラーテストとシステムテストを追加