### PR TITLE
単語管理ページに複数選択・一括削除機能を追加

### DIFF
--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -25,6 +25,31 @@ class WordsController < ApplicationController
     redirect_to words_path
   end
 
+  def bulk_destroy
+    if params[:word_ids].blank?
+      flash[:alert] = "削除する単語を選択してください。"
+      redirect_to words_path
+      return
+    end
+
+    word_ids = params[:word_ids].keys
+    deleted_count = 0
+
+    begin
+      Word.transaction do
+        words = Word.where(id: word_ids)
+        deleted_count = words.count
+        words.destroy_all
+      end
+
+      flash[:notice] = "#{deleted_count}件の単語を削除しました。"
+    rescue => e
+      flash[:alert] = "単語の削除に失敗しました。エラー: #{e.message}"
+    end
+
+    redirect_to words_path
+  end
+
   def download
     @words = Word.all.order(:word)
 

--- a/app/javascript/controllers/bulk_delete_controller.js
+++ b/app/javascript/controllers/bulk_delete_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus";
+
+// 複数選択削除機能のコントローラー
+export default class extends Controller {
+  static targets = ["selectAll", "wordCheckbox", "bulkDeleteButton"];
+
+  connect() {
+    this.updateBulkDeleteButton();
+  }
+
+  // 全選択チェックボックスの切り替え
+  toggleAll() {
+    const checked = this.selectAllTarget.checked;
+    this.wordCheckboxTargets.forEach((checkbox) => {
+      checkbox.checked = checked;
+    });
+    this.updateBulkDeleteButton();
+  }
+
+  // 個別チェックボックスの切り替え
+  toggleOne() {
+    // 全てのチェックボックスがチェックされているか確認
+    const allChecked = this.wordCheckboxTargets.every(
+      (checkbox) => checkbox.checked
+    );
+    this.selectAllTarget.checked = allChecked;
+
+    this.updateBulkDeleteButton();
+  }
+
+  // 削除ボタンの有効/無効を切り替え
+  updateBulkDeleteButton() {
+    const anyChecked = this.wordCheckboxTargets.some(
+      (checkbox) => checkbox.checked
+    );
+    this.bulkDeleteButtonTarget.disabled = !anyChecked;
+  }
+}

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -60,38 +60,72 @@ keyword_example,keyword,This is a keyword example</pre>
         <% end %>
       </div>
 
-      <div class="table-responsive">
-        <table class="table table-striped table-hover">
-          <thead>
-            <tr>
-              <th>単語</th>
-              <th>種類</th>
-              <th>説明</th>
-              <th>操作</th>
-            </tr>
-          </thead>
-          <tbody>
-            <% if @words.any? %>
-              <% @words.each do |word| %>
+      <div data-controller="bulk-delete">
+        <%= form_with url: bulk_destroy_words_path, method: :delete, local: true, id: "bulk-delete-form" do |form| %>
+          <div class="mb-3 d-flex justify-content-end">
+            <%= form.submit "選択した単語を削除", class: "btn btn-danger",
+                data: {
+                  turbo_confirm: "選択した単語を削除してもよろしいですか？",
+                  bulk_delete_target: "bulkDeleteButton"
+                },
+                disabled: true %>
+          </div>
+
+          <div class="table-responsive">
+            <table class="table table-striped table-hover">
+              <thead>
                 <tr>
-                  <td><%= word.word %></td>
-                  <td><%= word.word_type %></td>
-                  <td><%= word.description %></td>
-                  <td>
-                    <%= link_to "削除", word_path(word),
-                        method: :delete,
-                        data: { turbo_method: :delete, turbo_confirm: "単語「#{word.word}」を削除してもよろしいですか？" },
-                        class: "btn btn-sm btn-danger" %>
-                  </td>
+                  <th>
+                    <div class="form-check">
+                      <%= check_box_tag "select-all", "", false,
+                          class: "form-check-input",
+                          data: {
+                            bulk_delete_target: "selectAll",
+                            action: "change->bulk-delete#toggleAll"
+                          } %>
+                      <label class="form-check-label" for="select-all">全選択</label>
+                    </div>
+                  </th>
+                  <th>単語</th>
+                  <th>種類</th>
+                  <th>説明</th>
+                  <th>操作</th>
                 </tr>
-              <% end %>
-            <% else %>
-              <tr>
-                <td colspan="4" class="text-center">単語が見つかりません</td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+              </thead>
+              <tbody>
+                <% if @words.any? %>
+                  <% @words.each do |word| %>
+                    <tr>
+                      <td>
+                        <div class="form-check">
+                          <%= check_box_tag "word_ids[#{word.id}]", word.id, false,
+                              class: "form-check-input",
+                              data: {
+                                bulk_delete_target: "wordCheckbox",
+                                action: "change->bulk-delete#toggleOne"
+                              } %>
+                        </div>
+                      </td>
+                      <td><%= word.word %></td>
+                      <td><%= word.word_type %></td>
+                      <td><%= word.description %></td>
+                      <td>
+                        <%= link_to "削除", word_path(word),
+                            method: :delete,
+                            data: { turbo_method: :delete, turbo_confirm: "単語「#{word.word}」を削除してもよろしいですか？" },
+                            class: "btn btn-sm btn-danger" %>
+                      </td>
+                    </tr>
+                  <% end %>
+                <% else %>
+                  <tr>
+                    <td colspan="5" class="text-center">単語が見つかりません</td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        <% end %>
       </div>
 
       <div class="d-flex justify-content-center mt-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     collection do
       get :download
       post :upload
+      delete :bulk_destroy
     end
   end
 

--- a/spec/controllers/words_controller_spec.rb
+++ b/spec/controllers/words_controller_spec.rb
@@ -157,6 +157,43 @@ RSpec.describe WordsController, type: :controller do
         expect(flash[:alert]).to include("CSVファイルのみアップロード可能です")
       end
     end
+
+    describe "DELETE #bulk_destroy" do
+      context "with selected word ids" do
+        it "deletes multiple words" do
+          word1 = create(:word, word: "bulk_delete_test1")
+          word2 = create(:word, word: "bulk_delete_test2")
+          word3 = create(:word, word: "bulk_delete_test3")
+
+          expect {
+            delete :bulk_destroy, params: { word_ids: { word1.id.to_s => word1.id, word2.id.to_s => word2.id } }
+          }.to change(Word, :count).by(-2)
+
+          expect(Word.find_by(id: word1.id)).to be_nil
+          expect(Word.find_by(id: word2.id)).to be_nil
+          expect(Word.find_by(id: word3.id)).to be_present
+        end
+
+        it "redirects to words_path with a success message" do
+          word1 = create(:word, word: "bulk_delete_test4")
+          word2 = create(:word, word: "bulk_delete_test5")
+
+          delete :bulk_destroy, params: { word_ids: { word1.id.to_s => word1.id, word2.id.to_s => word2.id } }
+
+          expect(response).to redirect_to(words_path)
+          expect(flash[:notice]).to include("2件の単語を削除しました")
+        end
+      end
+
+      context "with no word ids" do
+        it "redirects to words_path with an alert message" do
+          delete :bulk_destroy
+
+          expect(response).to redirect_to(words_path)
+          expect(flash[:alert]).to include("削除する単語を選択してください")
+        end
+      end
+    end
   end
 
   describe "DELETE #destroy" do

--- a/spec/system/words_spec.rb
+++ b/spec/system/words_spec.rb
@@ -143,4 +143,36 @@ RSpec.describe "Words", type: :system do
       expect(page).not_to have_content(@word.word)
     end
   end
+
+  describe "複数選択削除機能", js: false do
+    before do
+      # テスト用の単語を作成
+      @word1 = create(:word, word: "bulk_delete_test1", description: "Bulk delete test 1")
+      @word2 = create(:word, word: "bulk_delete_test2", description: "Bulk delete test 2")
+      @word3 = create(:word, word: "bulk_delete_test3", description: "Bulk delete test 3")
+
+      visit words_path
+    end
+
+    it "複数の単語を選択して一括削除できる" do
+      # 削除前の単語数を記録
+      initial_count = Word.count
+
+      # 単語を選択
+      check "word_ids[#{@word1.id}]"
+      check "word_ids[#{@word2.id}]"
+
+      # 削除ボタンを直接送信（JavaScriptなしのテストのため）
+      page.driver.submit :delete, bulk_destroy_words_path, { "word_ids" => { @word1.id.to_s => @word1.id, @word2.id.to_s => @word2.id } }
+
+      # 削除後のページを表示
+      visit words_path
+
+      # 単語が削除されたことを確認
+      expect(Word.count).to eq(initial_count - 2)
+      expect(page).not_to have_content(@word1.word)
+      expect(page).not_to have_content(@word2.word)
+      expect(page).to have_content(@word3.word)
+    end
+  end
 end


### PR DESCRIPTION
## 変更の概要

- 単語管理ページに複数選択・一括削除機能を追加

## 詳細

- 単語一覧に各行のチェックボックスを追加
- 全選択チェックボックスを追加
- 選択した単語を一括削除するボタンを追加
- 一括削除処理を行うアクションを追加
- JavaScriptで選択状態を管理
- コントローラーテストとシステムテストを追加