### PR TITLE
ゲーム終了画面の単語一覧に説明カラムを追加

### DIFF
--- a/app/assets/stylesheets/game.css
+++ b/app/assets/stylesheets/game.css
@@ -109,6 +109,7 @@
   border-radius: 4px;
   padding: 0.5rem;
   overflow-y: visible;
+  width: 100%;
 }
 
 .word-list li {
@@ -120,6 +121,40 @@
 
 .word-list li:last-child {
   border-bottom: none;
+}
+
+/* 単語一覧のヘッダー */
+.word-list .word-header {
+  font-weight: bold;
+  background-color: var(--light-gray);
+  padding: 0.75rem 0.5rem;
+  border-bottom: 2px solid var(--primary-color);
+}
+
+/* 単語一覧の各カラム */
+.word-turn, .word-text, .word-player, .word-description {
+  padding: 0 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.word-turn {
+  width: 10%;
+  text-align: center;
+}
+
+.word-text {
+  width: 25%;
+}
+
+.word-player {
+  width: 20%;
+  text-align: center;
+}
+
+.word-description {
+  width: 45%;
+  font-size: 0.9rem;
 }
 
 .word-list .player-word {
@@ -331,5 +366,31 @@
 
   .submit-button {
     width: 100%;
+  }
+
+  /* スマホ表示時の単語一覧 */
+  .word-list li {
+    flex-wrap: wrap;
+  }
+
+  .word-turn {
+    width: 15%;
+  }
+
+  .word-text {
+    width: 40%;
+  }
+
+  .word-player {
+    width: 45%;
+    text-align: right;
+  }
+
+  .word-description {
+    width: 100%;
+    padding-top: 0.25rem;
+    padding-left: 15%;
+    font-size: 0.85rem;
+    color: var(--secondary-color);
   }
 }

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -376,21 +376,106 @@ export default class extends Controller {
     const gameOverWordList = document.getElementById("game-over-word-list");
     gameOverWordList.innerHTML = ""; // リストをクリア
 
-    this.gameState.usedWords.forEach((word, index) => {
-      const li = document.createElement("li");
-      const player = index % 2 === 0 ? "player" : "computer";
-      li.className = player === "player" ? "player-word" : "computer-word";
+    // テーブルヘッダーを作成
+    const tableHeader = document.createElement("li");
+    tableHeader.className = "word-header";
 
-      // 単語と番号を表示
-      const turnNumber = index + 1;
-      const turnNumberSpan = document.createElement("span");
-      turnNumberSpan.textContent = `${turnNumber}. ${word}`;
-      const playerSpan = document.createElement("span");
-      playerSpan.textContent = player === "player" ? "あなた" : "コンピューター";
-      li.appendChild(turnNumberSpan);
-      li.appendChild(playerSpan);
-      gameOverWordList.appendChild(li);
-    });
+    const turnHeader = document.createElement("span");
+    turnHeader.className = "word-turn";
+    turnHeader.textContent = "ターン";
+
+    const wordHeader = document.createElement("span");
+    wordHeader.className = "word-text";
+    wordHeader.textContent = "単語";
+
+    const playerHeader = document.createElement("span");
+    playerHeader.className = "word-player";
+    playerHeader.textContent = "プレイヤー";
+
+    const descHeader = document.createElement("span");
+    descHeader.className = "word-description";
+    descHeader.textContent = "説明";
+
+    tableHeader.appendChild(turnHeader);
+    tableHeader.appendChild(wordHeader);
+    tableHeader.appendChild(playerHeader);
+    tableHeader.appendChild(descHeader);
+    gameOverWordList.appendChild(tableHeader);
+
+    // APIから単語の説明が含まれている場合はそれを使用
+    if (
+      data.words_with_descriptions &&
+      data.words_with_descriptions.length > 0
+    ) {
+      data.words_with_descriptions.forEach((wordData, index) => {
+        const li = document.createElement("li");
+        li.className =
+          wordData.player === "player" ? "player-word" : "computer-word";
+
+        // ターン番号
+        const turnNumber = index + 1;
+        const turnNumberSpan = document.createElement("span");
+        turnNumberSpan.className = "word-turn";
+        turnNumberSpan.textContent = turnNumber;
+
+        // 単語
+        const wordSpan = document.createElement("span");
+        wordSpan.className = "word-text";
+        wordSpan.textContent = wordData.word;
+
+        // プレイヤー
+        const playerSpan = document.createElement("span");
+        playerSpan.className = "word-player";
+        playerSpan.textContent =
+          wordData.player === "player" ? "あなた" : "コンピューター";
+
+        // 説明
+        const descSpan = document.createElement("span");
+        descSpan.className = "word-description";
+        descSpan.textContent = wordData.description || "説明なし";
+
+        li.appendChild(turnNumberSpan);
+        li.appendChild(wordSpan);
+        li.appendChild(playerSpan);
+        li.appendChild(descSpan);
+        gameOverWordList.appendChild(li);
+      });
+    } else {
+      // 後方互換性のために残す（APIが更新されていない場合）
+      this.gameState.usedWords.forEach((word, index) => {
+        const li = document.createElement("li");
+        const player = index % 2 === 0 ? "player" : "computer";
+        li.className = player === "player" ? "player-word" : "computer-word";
+
+        // ターン番号
+        const turnNumber = index + 1;
+        const turnNumberSpan = document.createElement("span");
+        turnNumberSpan.className = "word-turn";
+        turnNumberSpan.textContent = turnNumber;
+
+        // 単語
+        const wordSpan = document.createElement("span");
+        wordSpan.className = "word-text";
+        wordSpan.textContent = word;
+
+        // プレイヤー
+        const playerSpan = document.createElement("span");
+        playerSpan.className = "word-player";
+        playerSpan.textContent =
+          player === "player" ? "あなた" : "コンピューター";
+
+        // 説明（データがない場合）
+        const descSpan = document.createElement("span");
+        descSpan.className = "word-description";
+        descSpan.textContent = "説明なし";
+
+        li.appendChild(turnNumberSpan);
+        li.appendChild(wordSpan);
+        li.appendChild(playerSpan);
+        li.appendChild(descSpan);
+        gameOverWordList.appendChild(li);
+      });
+    }
   }
 
   // 秒数を「○分○秒」の形式にフォーマット

--- a/spec/system/game_spec.rb
+++ b/spec/system/game_spec.rb
@@ -10,4 +10,122 @@ RSpec.describe 'Game', type: :system do
     expect(page).to have_content('ShiritoRuby')
     expect(page).to have_content('Rubyしりとりゲーム')
   end
+
+  describe 'game over screen' do
+    before do
+      # テスト用の単語を作成
+      @word1 = create(:word, word: "ruby", word_type: "keyword", description: "プログラミング言語")
+      @word2 = create(:word, word: "yield", word_type: "keyword", description: "ブロックに制御を渡すキーワード")
+
+      # テスト用のゲームを作成
+      @game = create(:game, player_name: "テストプレイヤー", score: 10)
+
+      # ゲームに単語を関連付け
+      create(:game_word, game: @game, word: @word1, turn: 1)
+      create(:game_word, game: @game, word: @word2, turn: 2)
+    end
+
+    it 'displays word descriptions in the game over screen', js: true do
+      # APIレスポンスをモック
+      page.execute_script(<<~JS)
+        // オリジナルのfetchを保存
+        window._originalFetch = window.fetch;
+
+        // fetchをモック
+        window.fetch = function(url, options) {
+          if (url.includes('/api/games/timeout')) {
+            return Promise.resolve({
+              ok: true,
+              json: () => Promise.resolve({
+                game_over: true,
+                message: "制限時間を超過しました。コンピューターの勝利です。",
+                game: {
+                  id: #{@game.id},
+                  player_name: "テストプレイヤー",
+                  score: 10,
+                  duration_seconds: 60
+                },
+                words_with_descriptions: [
+                  {
+                    word: "ruby",
+                    description: "プログラミング言語",
+                    player: "player"
+                  },
+                  {
+                    word: "yield",
+                    description: "ブロックに制御を渡すキーワード",
+                    player: "computer"
+                  }
+                ]
+              })
+            });
+          }
+
+          // その他のリクエストは通常通り処理
+          return window._originalFetch(url, options);
+        };
+      JS
+
+      # ゲームページにアクセス
+      visit root_path
+
+      # プレイヤー名を入力してゲーム開始
+      fill_in "player-name", with: "テストプレイヤー"
+      click_button "ゲーム開始"
+
+      # カウントダウンが終わるまで待機
+      sleep 4
+
+      # タイムアウトをシミュレート - APIレスポンスを直接処理
+      page.execute_script(<<~JS)
+        // ゲームオーバー状態を直接設定
+        const gameController = document.querySelector('[data-controller="game"]');
+        const event = new CustomEvent('game:timeout', {
+          detail: {
+            game_over: true,
+            message: "制限時間を超過しました。コンピューターの勝利です。",
+            game: {
+              id: #{@game.id},
+              player_name: "テストプレイヤー",
+              score: 10,
+              duration_seconds: 60
+            },
+            words_with_descriptions: [
+              {
+                word: "ruby",
+                description: "プログラミング言語",
+                player: "player"
+              },
+              {
+                word: "yield",
+                description: "ブロックに制御を渡すキーワード",
+                player: "computer"
+              }
+            ]
+          }
+        });
+
+        // handleGameOverメソッドを直接呼び出す
+        const controller = window.Stimulus.getControllerForElementAndIdentifier(gameController, "game");
+        controller.handleGameOver(event.detail);
+      JS
+
+      # ゲーム終了画面が表示されるまで待機
+      expect(page).to have_content("ゲーム終了")
+
+      # 単語一覧のヘッダーが表示されていることを確認
+      within "#game-over-word-list" do
+        expect(page).to have_content("ターン")
+        expect(page).to have_content("単語")
+        expect(page).to have_content("プレイヤー")
+        expect(page).to have_content("説明")
+      end
+
+      # 単語とその説明が表示されていることを確認
+      expect(page).to have_content("ruby")
+      expect(page).to have_content("プログラミング言語")
+      expect(page).to have_content("yield")
+      expect(page).to have_content("ブロックに制御を渡すキーワード")
+    end
+  end
 end


### PR DESCRIPTION
## 変更の概要

- ゲーム終了画面に表示される単語一覧に「説明」カラムを追加
- APIレスポンスに単語の説明を含めるように修正
- 単語一覧のレイアウトを改善（テーブル形式に変更）
- レスポンシブ対応を強化

## 詳細

1. `Api::GamesController`の修正
   - `timeout`アクションと`submit_word`アクションに単語の説明を含めるように修正
   - `get_words_with_descriptions`メソッドを追加して、単語とその説明を取得

2. `game_controller.js`の`handleGameOver`メソッドの修正
   - テーブルヘッダーを追加
   - APIから返された`words_with_descriptions`を使用して単語リストを生成
   - 後方互換性のために、`words_with_descriptions`がない場合は従来の方法で単語リストを生成

3. CSSの追加
   - 単語一覧のヘッダーのスタイル
   - 各カラム（ターン、単語、プレイヤー、説明）のスタイル
   - レスポンシブ対応（スマホ表示時のレイアウト調整）

4. テストの追加
   - ゲーム終了画面で単語の説明が表示されることをテスト


<img width="728" alt="image" src="https://github.com/user-attachments/assets/f0b9b050-6a96-4669-9065-5153653e3dac" />
