### PR TITLE
Terraformインフラストラクチャの修正

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -9,6 +9,7 @@ data "external" "github_thumbprint" {
 
 # GitHub OIDC Provider
 resource "aws_iam_openid_connect_provider" "github" {
+  count           = var.use_existing_infrastructure ? 0 : 1
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = [data.external.github_thumbprint.result.thumbprint]

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -17,6 +17,7 @@ resource "aws_iam_openid_connect_provider" "github" {
 
 # GitHub Actions用のIAMロール
 resource "aws_iam_role" "github_actions" {
+  count = var.use_existing_infrastructure ? 0 : 1
   name = "github-actions-role"
 
   assume_role_policy = jsonencode({

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -44,8 +44,9 @@ resource "aws_iam_role" "github_actions" {
 
 # ECRとECSの権限をロールに付与
 resource "aws_iam_role_policy" "github_actions_ecr_ecs" {
+  count = var.use_existing_infrastructure ? 0 : 1
   name = "github-actions-ecr-ecs-policy"
-  role = aws_iam_role.github_actions.id
+  role = aws_iam_role.github_actions[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -95,8 +96,9 @@ resource "aws_iam_role_policy" "github_actions_ecr_ecs" {
 
 # Terraformインフラ作成のための追加権限
 resource "aws_iam_role_policy" "github_actions_terraform" {
+  count = var.use_existing_infrastructure ? 0 : 1
   name = "github-actions-terraform-policy"
-  role = aws_iam_role.github_actions.id
+  role = aws_iam_role.github_actions[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -25,7 +25,7 @@ resource "aws_iam_role" "github_actions" {
       {
         Effect = "Allow"
         Principal = {
-          Federated = aws_iam_openid_connect_provider.github.arn
+          Federated = aws_iam_openid_connect_provider.github[0].arn
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {


### PR DESCRIPTION
## 変更の概要

- GitHub Actionsが使用するIAMロールに必要な権限を追加
- 既存インフラを使用するように設定
- 既存リソースの再作成を防ぐための条件を追加

## 詳細

### 問題の原因
1. **IAMロールの権限不足**: GitHub Actionsが使用するIAMロールに必要な権限が不足していました
2. **既存リソースの再作成**: 既に存在するリソースを再作成しようとして競合が発生していました

### 解決策
以下の対応を行いました：

1. **IAMロールに必要な権限を追加**
   - GitHub Actionsが使用するIAMロール（github-actions-role）に以下の権限を追加：
     - `acm:ListTagsForCertificate`
     - `route53:ChangeTagsForResource`
     - `route53:GetChange`
     - `ec2:ModifyVpcAttribute`
     - `ec2:DescribeVpcAttribute`

2. **既存インフラを使用するように設定**
   - `terraform.tfvars`ファイルで`use_existing_infrastructure = true`に設定
   - GitHub Actionsのワークフローファイルに`-var="use_existing_infrastructure=true"`を追加

3. **リソース作成条件の追加**
   以下のリソースに`count = var.use_existing_infrastructure ? 0 : 1`の条件を追加：
   - Route53関連リソース（ホストゾーン、レコード、ACM証明書検証）
   - ACM証明書
   - ECRリポジトリ
   - ECSクラスター
   - CloudWatch Logsロググループ
   - IAM OIDCプロバイダー
   - IAMロール（ecs_task_execution_role、ecs_task_role）
   - ECSタスク定義
   - ECSサービス

4. **リソース参照の修正**
   - `count`を追加したリソースの参照を`resource_name.id`から`resource_name[0].id`に修正

これらの変更により、GitHub Actionsのワークフローが既存のインフラを使用するようになり、リソースの再作成による競合が解消されます。