### PR TITLE
既存インフラ使用時の出力値を修正

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -71,12 +71,12 @@ output "domain_setup_instructions" {
 
 output "github_actions_role_arn" {
   description = "The ARN of the IAM role for GitHub Actions OIDC"
-  value       = aws_iam_role.github_actions[0].arn
+  value       = var.use_existing_infrastructure ? "Using existing GitHub Actions role" : aws_iam_role.github_actions[0].arn
 }
 
 output "github_actions_oidc_setup" {
   description = "Instructions for setting up GitHub Actions OIDC authentication"
-  value       = <<EOF
+  value       = var.use_existing_infrastructure ? "Using existing GitHub Actions OIDC setup" : <<EOF
 # GitHub ActionsでOIDC認証を使用するための設定手順
 
 1. GitHubリポジトリの「Settings」→「Secrets and variables」→「Actions」で以下のシークレットを設定します：


### PR DESCRIPTION
## 変更の概要

- 既存インフラ使用時の出力値を修正

## 詳細

### 問題の原因
`use_existing_infrastructure = true`を設定している場合、`aws_iam_role.github_actions`リソースが作成されないため、`outputs.tf`ファイルの以下の参照でエラーが発生していました：

```terraform
value = aws_iam_role.github_actions[0].arn
```

### 解決策
出力値に条件分岐を追加して、`use_existing_infrastructure = true`の場合は別の値を返すように修正しました：

```terraform
value = var.use_existing_infrastructure ? "Using existing GitHub Actions role" : aws_iam_role.github_actions[0].arn
```

これにより、既存インフラを使用する場合でもエラーが発生しなくなります。